### PR TITLE
TP-67: Update reminder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,6 +120,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "drupal/message": {
+                "https://www.drupal.org/files/issues/2018-06-24/allow_token_contexts-3.patch": "https://www.drupal.org/files/issues/2018-06-24/allow_token_contexts-3.patch"
+            }
         }
     }
 }

--- a/config/sync/core.entity_form_display.message.hel_tpm_update_reminder.default.yml
+++ b/config/sync/core.entity_form_display.message.hel_tpm_update_reminder.default.yml
@@ -1,0 +1,29 @@
+uuid: b10ddd17-cb5f-4f49-a350-5112f045a35d
+langcode: fi
+status: true
+dependencies:
+  config:
+    - message.template.hel_tpm_update_reminder
+id: message.hel_tpm_update_reminder.default
+targetEntityType: message
+bundle: hel_tpm_update_reminder
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    '#group': advanced
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.hel_tpm_update_reminder.default.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_update_reminder.default.yml
@@ -1,0 +1,24 @@
+uuid: 1f5fefd3-a644-47ba-a7dd-0571fa6a3031
+langcode: fi
+status: true
+dependencies:
+  config:
+    - message.template.hel_tpm_update_reminder
+  module:
+    - user
+id: message.hel_tpm_update_reminder.default
+targetEntityType: message
+bundle: hel_tpm_update_reminder
+mode: default
+content:
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  partial_1:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.message.hel_tpm_update_reminder.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_update_reminder.mail_body.yml
@@ -1,0 +1,21 @@
+uuid: ceababbc-b045-497f-a5d7-24f53d868f5e
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - message.template.hel_tpm_update_reminder
+  module:
+    - user
+id: message.hel_tpm_update_reminder.mail_body
+targetEntityType: message
+bundle: hel_tpm_update_reminder
+mode: mail_body
+content:
+  partial_0:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  partial_1: true

--- a/config/sync/core.entity_view_display.message.hel_tpm_update_reminder.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_update_reminder.mail_subject.yml
@@ -1,0 +1,21 @@
+uuid: 206fc540-f24c-4c9b-b9e7-e65d2d05218d
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - message.template.hel_tpm_update_reminder
+  module:
+    - user
+id: message.hel_tpm_update_reminder.mail_subject
+targetEntityType: message
+bundle: hel_tpm_update_reminder
+mode: mail_subject
+content:
+  partial_1:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  partial_0: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -30,6 +30,7 @@ module:
   gnode: 0
   group: 0
   hel_tpm_contact_info: 0
+  hel_tpm_update_reminder: 0
   image: 0
   inline_entity_form: 0
   language: 0

--- a/config/sync/language/fi/message.template.hel_tpm_update_reminder.yml
+++ b/config/sync/language/fi/message.template.hel_tpm_update_reminder.yml
@@ -1,0 +1,7 @@
+text:
+  -
+    value: "<p>Hi,</p>\r\n\r\n<p>The service&nbsp;[node:title] ([node:edit-url]) has not been updated for a long time. Please check that the information is still valid. When checking, open the service node in edit mode and save it again.</p>\r\n"
+    format: filtered_html
+  -
+    value: "<p>Työllisyyspalvelumanuaali: Remember to update your service</p>\r\n"
+    format: filtered_html

--- a/config/sync/message.template.hel_tpm_update_reminder.yml
+++ b/config/sync/message.template.hel_tpm_update_reminder.yml
@@ -1,0 +1,22 @@
+uuid: d5eee5be-202c-4d87-9b2f-13e3c28cf407
+langcode: fi
+status: true
+dependencies:
+  config:
+    - filter.format.filtered_html
+template: hel_tpm_update_reminder
+label: 'Update reminder'
+description: ''
+text:
+  -
+    value: "<p>Hi,</p>\r\n\r\n<p>The service&nbsp;[node:title] ([node:edit-url]) has not been updated for a long time. Please check that the information is still valid. When checking, open the service node in edit mode and save it again.</p>\r\n"
+    format: filtered_html
+  -
+    value: "<p>Työllisyyspalvelumanuaali: Remember to update your service</p>\r\n"
+    format: filtered_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.info.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.info.yml
@@ -1,0 +1,7 @@
+name: Helsinki TPM Contact Info
+type: module
+description: 'Provides a contact info entity.'
+package: Custom
+core: 8.x
+core_version_requirement: ^8 || ^9
+configure: entity.contact_info.settings

--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.info.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.info.yml
@@ -1,7 +1,6 @@
-name: Helsinki TPM Contact Info
+name: Helsinki TPM Update reminder
 type: module
-description: 'Provides a contact info entity.'
+description: 'Reminds users to periodically check their services.'
 package: Custom
 core: 8.x
 core_version_requirement: ^8 || ^9
-configure: entity.contact_info.settings

--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
@@ -1,7 +1,10 @@
 <?php
 
+/**
+ * Implements hook_cron().
+ */
 function hel_tpm_update_reminder_cron() {
-  $ago = time()-(60*60*24*30*6);
+  $ago = strtotime('-6 months');
   $query = \Drupal::entityQuery('node')
     ->condition('type', 'service')
     ->condition('changed', $ago, '<');
@@ -15,7 +18,7 @@ function hel_tpm_update_reminder_cron() {
     $last_reminded = \Drupal::state()->get($state_id);
 
     // We haven't reminded about this yet or in two weeks.
-    if ($last_reminded == NULL || $last_reminded < (time() - (60*60*24*14))) {
+    if ($last_reminded == NULL || $last_reminded < (time() - strtotime('-2 weeks'))) {
       $node = $nodeStorage->load($nid);
       $user = $node->getOwner();
       $email = $user->getEmail();
@@ -32,6 +35,9 @@ function hel_tpm_update_reminder_cron() {
   \Drupal::logger('hel_tpm_update_reminder')->notice('Sent update reminders for %count expired nodes.', ['%count' => $sent]);
 }
 
+/**
+ * Implements hook_mail().
+ */
 function hel_tpm_update_reminder_mail($key, &$message, $params) {
   $variables = [
     '@service' => $params['service_name'],

--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
@@ -1,0 +1,48 @@
+<?php
+
+function hel_tpm_update_reminder_cron() {
+  $ago = time()-(60*60*24*30*6);
+  $query = \Drupal::entityQuery('node')
+    ->condition('type', 'service')
+    ->condition('changed', $ago, '<');
+  $results = $query->execute();
+
+  $nodeStorage = \Drupal::entityTypeManager()->getStorage('node');
+  \Drupal::logger('hel_tpm_update_reminder')->notice('Found %count expired nodes.', ['%count' => count($results)]);
+  $sent = 0;
+  foreach ($results as $nid) {
+    $state_id = 'hel_tpm.update_reminder.' . $nid;
+    $last_reminded = \Drupal::state()->get($state_id);
+
+    // We haven't reminded about this yet or in two weeks.
+    if ($last_reminded == NULL || $last_reminded < (time() - (60*60*24*14))) {
+      $node = $nodeStorage->load($nid);
+      $user = $node->getOwner();
+      $email = $user->getEmail();
+      $params = [
+        'service_name' => (string) $node->getTitle(),
+        'service_url' => $node->toUrl('edit-form')->setAbsolute()->toString(),
+      ];
+      \Drupal::service('plugin.manager.mail')
+        ->mail('hel_tpm_update_reminder', 'update_reminder', $email, $langcode, $params);
+      \Drupal::state()->set($state_id, time());
+      $sent++;
+    }
+  }
+  \Drupal::logger('hel_tpm_update_reminder')->notice('Sent update reminders for %count expired nodes.', ['%count' => $sent]);
+}
+
+function hel_tpm_update_reminder_mail($key, &$message, $params) {
+  $variables = [
+    '@service' => $params['service_name'],
+    '@url' => $params['service_url'],
+  ];
+  $options['langcode'] = $message['langcode'];
+
+  switch ($key) {
+    case 'update_reminder':
+      $message['subject'] = t('Työllisyyspalvelumanuaali: Remember to update your service', $variables, $options);
+      $message['body'][] = t("Hi,\n\nThe service @service (@url) has not been updated for a long time. Please check that the information is still valid. When checking, open the service node in edit mode and save it again.", $variables, $options);
+      break;
+  }
+}

--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\message\Entity\Message;
+
 /**
  * Implements hook_cron().
  */
@@ -20,35 +22,20 @@ function hel_tpm_update_reminder_cron() {
     // We haven't reminded about this yet or in two weeks.
     if ($last_reminded == NULL || $last_reminded < (time() - strtotime('-2 weeks'))) {
       $node = $nodeStorage->load($nid);
-      $user = $node->getOwner();
-      $email = $user->getEmail();
-      $params = [
-        'service_name' => (string) $node->getTitle(),
-        'service_url' => $node->toUrl('edit-form')->setAbsolute()->toString(),
-      ];
-      \Drupal::service('plugin.manager.mail')
-        ->mail('hel_tpm_update_reminder', 'update_reminder', $email, $langcode, $params);
+      $account = $node->getOwner();
+      $email = $account->getEmail();
+
+      $message = Message::create(['template' => 'hel_tpm_update_reminder', 'uid' => $account->id()]);
+      $message->setOwner($account)
+        ->addContext('node', $node)
+        ->save();
+
+      $notifier = Drupal::service('message_notify.sender');
+      $notifier->send($message);
+
       \Drupal::state()->set($state_id, time());
       $sent++;
     }
   }
   \Drupal::logger('hel_tpm_update_reminder')->notice('Sent update reminders for %count expired nodes.', ['%count' => $sent]);
-}
-
-/**
- * Implements hook_mail().
- */
-function hel_tpm_update_reminder_mail($key, &$message, $params) {
-  $variables = [
-    '@service' => $params['service_name'],
-    '@url' => $params['service_url'],
-  ];
-  $options['langcode'] = $message['langcode'];
-
-  switch ($key) {
-    case 'update_reminder':
-      $message['subject'] = t('Työllisyyspalvelumanuaali: Remember to update your service', $variables, $options);
-      $message['body'][] = t("Hi,\n\nThe service @service (@url) has not been updated for a long time. Please check that the information is still valid. When checking, open the service node in edit mode and save it again.", $variables, $options);
-      break;
-  }
 }


### PR DESCRIPTION
drush cim

1. Change the $ago condition to days or weeks.
2. Run drush cron twice. If you have any over day-old service nodes the first run should send a reminder email to the author (captured by Mailhog), the second one should find the node but not send another email.