### PR TITLE
TP-163: Add an ”on hold” status to the services

### DIFF
--- a/config/sync/search_api.index.service_search_index.yml
+++ b/config/sync/search_api.index.service_search_index.yml
@@ -13,6 +13,7 @@ dependencies:
     - core.entity_view_mode.node.full
   module:
     - node
+    - content_moderation
     - paragraphs
     - search_api
 id: service_search_index
@@ -75,6 +76,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_service_time_and_location
+  moderation_state:
+    label: 'Moderation state'
+    datasource_id: 'entity:node'
+    property_path: moderation_state
+    type: string
+    dependencies:
+      module:
+        - content_moderation
   node_grants:
     label: 'Node access information'
     property_path: search_api_node_grants
@@ -142,6 +151,7 @@ processor_settings:
       preprocess_query: -15
     all_fields: true
     fields:
+      - moderation_state
       - rendered_item
       - title
     title: true
@@ -158,6 +168,7 @@ processor_settings:
       preprocess_query: -20
     all_fields: true
     fields:
+      - moderation_state
       - rendered_item
       - title
   language_with_fallback: {  }
@@ -168,6 +179,7 @@ processor_settings:
       preprocess_query: -20
     all_fields: true
     fields:
+      - moderation_state
       - rendered_item
       - title
 tracker_settings:

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -3,6 +3,7 @@ langcode: fi
 status: true
 dependencies:
   module:
+    - content_moderation
     - node
     - user
 _core:
@@ -165,6 +166,69 @@ display:
             format: custom
             format_custom_false: Julkaisematon
             format_custom_true: Julkaistu
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_field
+          label: 'Moderation state'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: content_moderation_state
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         changed:
           id: changed
           table: node_field_data

--- a/config/sync/views.view.service_search.yml
+++ b/config/sync/views.view.service_search.yml
@@ -444,6 +444,55 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        moderation_state:
+          id: moderation_state
+          table: search_api_index_service_search_index
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_string
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: published
+          group: 1
+          exposed: true
+          expose:
+            operator_id: moderation_state_op
+            label: 'Moderation state'
+            description: ''
+            use_operator: false
+            operator: moderation_state_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: moderation_state
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              root: '0'
+              admin: '0'
+              editor: '0'
+              specialist: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: default
         options:

--- a/config/sync/views.view.services.yml
+++ b/config/sync/views.view.services.yml
@@ -4,7 +4,9 @@ status: true
 dependencies:
   config:
     - node.type.service
+    - workflows.workflow.service_moderation
   module:
+    - content_moderation
     - node
     - taxonomy
     - user
@@ -197,9 +199,55 @@ display:
           plugin_id: bundle
           value:
             service: service
+          group: 1
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            service_moderation-published: service_moderation-published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: moderation_state_op
+            label: 'Moderation state'
+            description: null
+            use_operator: false
+            operator: moderation_state_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: moderation_state
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -233,7 +281,8 @@ display:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   block_1:
     id: block_1
     display_title: 'Front page users'
@@ -252,7 +301,8 @@ display:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   block_2:
     id: block_2
     display_title: 'Front page content producers'
@@ -506,6 +556,8 @@ display:
           field_api_classes: false
       defaults:
         fields: false
+        filters: true
+        filter_groups: true
       display_description: ''
       display_extenders: {  }
     cache_metadata:
@@ -515,7 +567,8 @@ display:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   block_3:
     id: block_3
     display_title: 'Popular services'
@@ -566,4 +619,5 @@ display:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'

--- a/config/sync/workflows.workflow.service_moderation.yml
+++ b/config/sync/workflows.workflow.service_moderation.yml
@@ -18,9 +18,14 @@ type_settings:
       default_revision: true
     draft:
       label: Draft
-      weight: -3
+      weight: -4
       published: false
       default_revision: false
+    on_hold:
+      label: 'On hold'
+      weight: -1
+      published: true
+      default_revision: true
     outdated:
       label: Outdated
       weight: 0
@@ -28,12 +33,12 @@ type_settings:
       default_revision: true
     published:
       label: Published
-      weight: -1
+      weight: -2
       published: true
       default_revision: true
     ready_to_publish:
       label: 'Ready to publish'
-      weight: -2
+      weight: -3
       published: false
       default_revision: true
     temporarily_archived:
@@ -46,11 +51,12 @@ type_settings:
       label: Archived
       from:
         - archived
+        - on_hold
         - outdated
         - published
         - temporarily_archived
       to: archived
-      weight: 2
+      weight: 3
     create_new_draft:
       label: 'Create New Draft'
       from:
@@ -65,15 +71,22 @@ type_settings:
         - outdated
         - published
       to: outdated
-      weight: 0
+      weight: 1
     publish:
       label: Publish
       from:
         - draft
+        - on_hold
         - published
         - ready_to_publish
       to: published
       weight: -1
+    put_on_hold:
+      label: 'Put on hold'
+      from:
+        - published
+      to: on_hold
+      weight: 0
     ready_to_publish:
       label: 'Ready to publish'
       from:
@@ -90,11 +103,12 @@ type_settings:
     temporarily_archived:
       label: 'Temporarily archived'
       from:
+        - on_hold
         - outdated
         - published
         - temporarily_archived
       to: temporarily_archived
-      weight: 1
+      weight: 2
   entity_types:
     node:
       - service

--- a/public/modules/custom/hel_tpm_editorial/hel_tpm_editorial.module
+++ b/public/modules/custom/hel_tpm_editorial/hel_tpm_editorial.module
@@ -7,3 +7,14 @@ function hel_tpm_editorial_entity_base_field_info_alter(&$fields, EntityTypeInte
     $fields['publish_end_date']->addConstraint('NotificationMessageExpiry');
   }
 }
+
+function hel_tpm_editorial_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  if (isset($form['moderation_state'])) {
+    $form['moderation_state']['#type'] = 'select';
+    $form['moderation_state']['#options'] = [
+      'published' => t('Published'),
+      'on_hold' => t('On hold'),
+    ];
+    unset($form['moderation_state']['#size']);
+  }
+}


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

drush cr; drush cim

**Testing instructions:**
- [x] Move one of your services to the ”on hold” state.
- [x] Re-index all content in /admin/config/search/search-api
- [x] Check that the on hold service doesn't show up in lists by default.
- [x] Check that you can select On hold as a status in the search and the service shows up.