### PR TITLE
Changed minimum keyword length for autocomplete

### DIFF
--- a/config/sync/search_api_autocomplete.search.solr_service_search.yml
+++ b/config/sync/search_api_autocomplete.search.solr_service_search.yml
@@ -37,7 +37,7 @@ search_settings:
       selected: {  }
 options:
   limit: 10
-  min_length: 1
+  min_length: 3
   show_count: false
   delay: null
   submit_button_selector: ':submit'


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Start writing search term, confirm there is no suggested nodes before there is 3 characters

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
