### PR TITLE
Changed some of untranslatable the paragraph field widgets to ief

### DIFF
--- a/config/sync/core.entity_form_display.node.service.default.yml
+++ b/config/sync/core.entity_form_display.node.service.default.yml
@@ -671,8 +671,8 @@ content:
     weight: 11
     region: content
     settings:
-      title: Paragraph
-      title_plural: Paragraphs
+      title: ' Kuntakohtaiset poikkeustilanteet'
+      title_plural: ' Kuntakohtaiset poikkeustilanteet'
       edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
@@ -846,23 +846,17 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_service_time_and_location:
-    type: paragraphs
+    type: inline_entity_form_simple
     weight: 17
     region: content
     settings:
-      title: Paragraph
-      title_plural: Paragraphs
-      edit_mode: open
-      closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: service_time_and_place
-      features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
-        duplicate: duplicate
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      collapsible: false
+      collapsed: false
+      revision: false
     third_party_settings: {  }
   field_statements:
     type: options_buttons
@@ -879,16 +873,17 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_target_group:
-    type: entity_reference_paragraphs
+    type: inline_entity_form_simple
     weight: 11
     region: content
     settings:
-      title: Paragraph
-      title_plural: Paragraphs
-      edit_mode: open
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: target_group
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      collapsible: false
+      collapsed: false
+      revision: false
     third_party_settings: {  }
   hel_tpm_service_help:
     weight: 0


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush deploy


**Testing instructions:**
- [x] Login and create a service
- [x] Add translation
- [x] Check that untranslatable paragraph reference fields wont show up

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
