### PR TITLE
TP-851: Change role permissions and views access

### DIFF
--- a/config/sync/group.role.organisation-administrator.yml
+++ b/config/sync/group.role.organisation-administrator.yml
@@ -13,7 +13,7 @@ third_party_settings:
       specialist_editor: specialist_editor
 id: organisation-administrator
 label: 'Group admin'
-weight: 7
+weight: -8
 internal: false
 audience: member
 group_type: organisation

--- a/config/sync/group.role.organisation-editor.yml
+++ b/config/sync/group.role.organisation-editor.yml
@@ -13,7 +13,7 @@ third_party_settings:
       specialist_editor: specialist_editor
 id: organisation-editor
 label: Editor
-weight: 8
+weight: -9
 internal: false
 audience: member
 group_type: organisation

--- a/config/sync/group.role.organisation-expert.yml
+++ b/config/sync/group.role.organisation-expert.yml
@@ -6,7 +6,7 @@ dependencies:
     - group.type.organisation
 id: organisation-expert
 label: Expert
-weight: 9
+weight: -10
 internal: false
 audience: member
 group_type: organisation

--- a/config/sync/group.role.service_provider-editor.yml
+++ b/config/sync/group.role.service_provider-editor.yml
@@ -13,20 +13,19 @@ third_party_settings:
       specialist_editor: 0
 id: service_provider-editor
 label: Editor
-weight: 9
+weight: -10
 internal: false
 audience: member
 group_type: service_provider
 permissions_ui: true
 permissions:
-  - 'access group_node overview'
-  - 'access subgroup overview'
   - 'create group_node:service entity'
   - 'create group_node:service_location entity'
   - 'delete any group_node:service content'
   - 'delete any group_node:service entity'
   - 'delete any group_node:service_location content'
   - 'delete any group_node:service_location entity'
+  - 'leave group'
   - 'update any group_node:service content'
   - 'update any group_node:service entity'
   - 'update any group_node:service_location content'
@@ -36,14 +35,12 @@ permissions:
   - 'use service_moderation transition outdated'
   - 'use service_moderation transition ready_to_publish'
   - 'use service_moderation transition temporarily_archived'
-  - 'view any unpublished group'
   - 'view group'
   - 'view group revisions'
   - 'view group_node:service content'
   - 'view group_node:service entity'
   - 'view group_node:service_location content'
   - 'view group_node:service_location entity'
-  - 'view latest group version'
   - 'view latest version'
   - 'view unpublished group_node:service entity'
   - 'view unpublished group_node:service_location entity'

--- a/config/sync/group.role.service_provider-group_admin.yml
+++ b/config/sync/group.role.service_provider-group_admin.yml
@@ -19,8 +19,6 @@ audience: member
 group_type: service_provider
 permissions_ui: true
 permissions:
-  - 'access group_node overview'
-  - 'access subgroup overview'
   - 'administer members'
   - 'create group_node:service entity'
   - 'create group_node:service_location entity'
@@ -28,7 +26,6 @@ permissions:
   - 'delete any group_node:service_location content'
   - 'delete any group_node:service_location entity'
   - 'delete any invitation'
-  - 'edit group'
   - 'invite users to group'
   - 'update any group_node:service content'
   - 'update any group_node:service entity'

--- a/config/sync/group.role.service_provider-member.yml
+++ b/config/sync/group.role.service_provider-member.yml
@@ -14,6 +14,5 @@ permissions_ui: true
 permissions:
   - 'leave group'
   - 'view group'
-  - 'view group_membership content'
   - 'view group_node:service entity'
   - 'view group_node:service_location entity'

--- a/config/sync/group.role.service_provider-organization_ad.yml
+++ b/config/sync/group.role.service_provider-organization_ad.yml
@@ -6,7 +6,7 @@ dependencies:
     - group.type.service_provider
 id: service_provider-organization_ad
 label: 'Organization admin'
-weight: -10
+weight: -8
 internal: false
 audience: member
 group_type: service_provider
@@ -22,11 +22,13 @@ permissions:
   - 'delete any group_node:service entity'
   - 'delete any group_node:service_location content'
   - 'delete any group_node:service_location entity'
+  - 'delete any invitation'
   - 'delete own group_node:service content'
   - 'delete own group_node:service entity'
   - 'delete own group_node:service_location content'
   - 'delete own group_node:service_location entity'
   - 'edit group'
+  - 'invite users to group'
   - 'leave group'
   - 'update any group_node:service content'
   - 'update any group_node:service entity'
@@ -47,6 +49,7 @@ permissions:
   - 'use service_moderation transition temporarily_archived'
   - 'view any unpublished group'
   - 'view group'
+  - 'view group invitations'
   - 'view group revisions'
   - 'view group_membership content'
   - 'view group_node:service content'

--- a/config/sync/views.view.group_invitations.yml
+++ b/config/sync/views.view.group_invitations.yml
@@ -724,7 +724,7 @@ display:
         type: tab
         title: Invitations
         description: 'Group invitations'
-        weight: 7
+        weight: 18
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_invitations.yml
+++ b/config/sync/views.view.group_invitations.yml
@@ -724,7 +724,7 @@ display:
         type: tab
         title: Invitations
         description: 'Group invitations'
-        weight: 25
+        weight: 7
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_members.yml
+++ b/config/sync/views.view.group_members.yml
@@ -793,7 +793,7 @@ display:
         type: tab
         title: Jäsenet
         description: ''
-        weight: 20
+        weight: 6
         enabled: true
         expanded: false
         menu_name: main

--- a/config/sync/views.view.group_members.yml
+++ b/config/sync/views.view.group_members.yml
@@ -793,7 +793,7 @@ display:
         type: tab
         title: Jäsenet
         description: ''
-        weight: 6
+        weight: 17
         enabled: true
         expanded: false
         menu_name: main

--- a/config/sync/views.view.group_service_locations.yml
+++ b/config/sync/views.view.group_service_locations.yml
@@ -485,7 +485,7 @@ display:
       access:
         type: group_permission
         options:
-          group_permission: 'access group_node overview'
+          group_permission: 'view unpublished group_node:service_location entity'
       cache:
         type: tag
         options: {  }

--- a/config/sync/views.view.group_service_locations.yml
+++ b/config/sync/views.view.group_service_locations.yml
@@ -809,7 +809,7 @@ display:
         type: tab
         title: Locations
         description: ''
-        weight: 8
+        weight: 19
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_service_locations.yml
+++ b/config/sync/views.view.group_service_locations.yml
@@ -809,7 +809,7 @@ display:
         type: tab
         title: Locations
         description: ''
-        weight: 25
+        weight: 8
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_services.yml
+++ b/config/sync/views.view.group_services.yml
@@ -616,7 +616,7 @@ display:
       access:
         type: group_permission
         options:
-          group_permission: 'access group_node overview'
+          group_permission: 'view unpublished group_node:service entity'
       cache:
         type: tag
         options: {  }
@@ -1014,7 +1014,7 @@ display:
         type: tab
         title: Services
         description: ''
-        weight: 25
+        weight: -25
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_services.yml
+++ b/config/sync/views.view.group_services.yml
@@ -1014,7 +1014,7 @@ display:
         type: tab
         title: Services
         description: ''
-        weight: -25
+        weight: 5
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_services.yml
+++ b/config/sync/views.view.group_services.yml
@@ -1014,7 +1014,7 @@ display:
         type: tab
         title: Services
         description: ''
-        weight: 5
+        weight: 16
         expanded: false
         menu_name: main
         parent: ''


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Login or create new user(s) in Service provider group
- [x] As a Group admin in Service provider group, you should see tabs Katsele|Jäsenet|Invitations|Services|Locations
- [x] As an Editor in Service provider group, you should see tabs Katsele|Services|Locations

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.

**Notes/Bugs:**
- User permissions are inherited from parent group, so if the user has privileges in Organization they'll also have them in the Service provider.
- Block "Tuottamamme palvelut" should be visible for Service provider users on the first tab, but isn't?