### PR TITLE
TP-890 disallowed group invitations tabs from other that admin and root roles

### DIFF
--- a/config/sync/views.view.group_invitations.yml
+++ b/config/sync/views.view.group_invitations.yml
@@ -4,6 +4,9 @@ status: true
 dependencies:
   config:
     - field.storage.group_content.group_roles
+    - field.storage.group_content.invitee_mail
+    - user.role.admin
+    - user.role.root
   module:
     - group
     - user
@@ -489,9 +492,11 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: group_permission
+        type: role
         options:
-          group_permission: 'administer members'
+          role:
+            root: root
+            admin: admin
       cache:
         type: tag
         options: {  }
@@ -707,8 +712,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - route.group
-        - user.group_permissions
+        - user.roles
       tags:
         - 'config:field.storage.group_content.group_roles'
         - 'config:field.storage.group_content.invitee_mail'
@@ -736,8 +740,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - route.group
-        - user.group_permissions
+        - user.roles
       tags:
         - 'config:field.storage.group_content.group_roles'
         - 'config:field.storage.group_content.invitee_mail'


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Login as non-admin user
- [x] Confirm invitations tab won't show
- [x] Login as admin
- [x] Confirm invitations tab shows

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
