### PR TITLE
TP-882 refactored subgroup services to list groups responsibility services

### DIFF
--- a/config/sync/language/en/views.view.group_subgroup_services.yml
+++ b/config/sync/language/en/views.view.group_subgroup_services.yml
@@ -1,0 +1,5 @@
+display:
+  page_1:
+    display_options:
+      menu:
+        title: 'Responsibility services'

--- a/config/sync/language/sv/views.view.group_subgroup_services.yml
+++ b/config/sync/language/sv/views.view.group_subgroup_services.yml
@@ -1,0 +1,5 @@
+display:
+  page_1:
+    display_options:
+      menu:
+        title: Ansvarstjänster

--- a/config/sync/views.view.group_subgroup_services.yml
+++ b/config/sync/views.view.group_subgroup_services.yml
@@ -641,26 +641,23 @@ display:
       empty: {  }
       sorts: {  }
       arguments:
-        gid:
-          id: gid
-          table: group_content_field_data
-          field: gid
-          relationship: group_content
+        field_responsible_municipality_target_id:
+          id: field_responsible_municipality_target_id
+          table: node__field_responsible_municipality
+          field: field_responsible_municipality_target_id
+          relationship: gc__node
           group_type: group
           admin_label: ''
-          entity_type: group_content
-          entity_field: gid
-          plugin_id: group_id
-          default_action: 'access denied'
+          plugin_id: numeric
+          default_action: default
           exception:
             value: all
             title_enable: false
             title: All
-          title_enable: true
-          title: '{{ arguments.gid|placeholder }} subgroups'
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
+          title_enable: false
+          title: ''
+          default_argument_type: group_id_from_url
+          default_argument_options: {  }
           default_argument_skip_url: false
           summary_options:
             base_path: ''
@@ -897,18 +894,6 @@ display:
           replica: false
           query_tags: {  }
       relationships:
-        group_content:
-          id: group_content
-          table: groups_field_data
-          field: group_content
-          relationship: none
-          group_type: group
-          admin_label: 'Subgroup relation'
-          entity_type: group
-          plugin_id: group_content_to_entity_reverse
-          required: true
-          group_content_plugins:
-            'subgroup:fut_open': '0'
         group_content_id:
           id: group_content_id
           table: groups_field_data
@@ -952,6 +937,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - route
         - route.group
         - url
         - url.query_args
@@ -1021,8 +1007,7 @@ display:
           entity_field: langcode
           plugin_id: language
           operator: in
-          value:
-            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          value: {  }
           group: 1
           exposed: true
           expose:
@@ -1163,10 +1148,10 @@ display:
         filters: false
         filter_groups: false
       display_extenders: {  }
-      path: group/%group/subgroup-services
+      path: group/%group/responsibility-services
       menu:
         type: tab
-        title: 'Subgroup services'
+        title: Vastuupalvelut
         description: ''
         weight: 27
         expanded: false
@@ -1178,6 +1163,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - route
         - route.group
         - url
         - url.query_args


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush deploy


**Testing instructions:**
- [x] Login and go to group
- [x] Confirm "vastuupalvelut" tab lists only services in which the group is referenced as "vastuukunta"

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
