### PR TITLE
TP-928 patched paragraphs legacy to always show default form even when entity is saved without value.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -292,6 +292,9 @@
             },
             "drupal/pathauto": {
                 "https://www.drupal.org/project/pathauto/issues/3039822#comment-13930768": "https://www.drupal.org/files/issues/2020-12-08/3039822-create-path-for-none-translate-6.patch"
+            },
+            "drupal/paragraphs": {
+                "https://www.drupal.org/project/paragraphs/issues/3248381#comment-14285361": "https://www.drupal.org/files/issues/2021-11-09/default_paragraphs_on_empty_fields-3248381-2.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0421d0e46ebf9baf1597684b9fb7da2",
+    "content-hash": "7f78633d68b69ae466c13b91538b93e0",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando composer install && lando drush cr 

**Testing instructions:**
- [x] Login and edit previously migrated service without ohjaus palveluun and / or merkinnät asiakastietorjärjestelmään
- [x] Confirm empty form fields are shown
- [x] Create new service
- [x] Confirm paragraph fields using paragraph legacy works as expected
- [ ] 

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
