### PR TITLE
Bug/tp 970 age groups range required

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.target_group.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.target_group.default.yml
@@ -24,8 +24,8 @@ content:
     region: content
     settings:
       label:
-        from: Lähettäjä
-        to: to
+        from: Ikävuodesta
+        to: Ikävuoteen
       placeholder:
         from: ''
         to: ''

--- a/public/modules/custom/hel_tpm_forms/hel_tpm_forms.module
+++ b/public/modules/custom/hel_tpm_forms/hel_tpm_forms.module
@@ -157,9 +157,17 @@ function _hel_tpm_forms_node_service_form_alter(&$form, FormStateInterface &$for
  * @return void
  */
 function _hel_tpm_form_validate_service_form(array &$form, FormStateInterface &$form_state): void {
+  // Check extra required fields only when form is publishing ready.
+  $require_fields = FALSE;
+  if ($moderation_state = $form_state->getValue('moderation_state')[0]['value']) {
+    if ($moderation_state === 'published' || $moderation_state === 'ready_to_publish') {
+      $require_fields = TRUE;
+    }
+  }
+
   // Check that age range is given, unless age group is selected. Not trying to
   // validate, if the field `field_target_group` is missing.
-  if ($target_group = $form_state->getValue('field_target_group')) {
+  if (($target_group = $form_state->getValue('field_target_group')) && $require_fields) {
     $age_groups = $target_group[0]['subform']['field_age_groups'][0]['value'] ?? NULL;
     $age_from = $target_group[0]['subform']['field_age'][0]['from'] ?? NULL;
     $age_to = $target_group[0]['subform']['field_age'][0]['to'] ?? NULL;

--- a/public/modules/custom/hel_tpm_forms/hel_tpm_forms.module
+++ b/public/modules/custom/hel_tpm_forms/hel_tpm_forms.module
@@ -122,13 +122,55 @@ function _hel_tpm_forms_node_service_form_alter(&$form, FormStateInterface &$for
     ],
   ];
 
+  // Require age range to be set, unless the `no age restriction` checkbox is
+  // checked.
+  $form['field_target_group']['widget'][0]['subform']['field_age']['widget'][0]['from']['#states'] = [
+    'required' => [
+      [':input[name="field_target_group[0][subform][field_age_groups][no_age_restriction]"]' => ['checked' => FALSE]],
+    ],
+  ];
+  $form['field_target_group']['widget'][0]['subform']['field_age']['widget'][0]['to']['#states'] = [
+    'required' => [
+      [':input[name="field_target_group[0][subform][field_age_groups][no_age_restriction]"]' => ['checked' => FALSE]],
+    ],
+  ];
+
   $form['paging_footer'] = [
     '#theme' => 'hel_tpm_steps',
   ];
 
   $form['#attached']['library'][] = 'hel_tpm_forms/hel_tpm_forms';
 
+  $form['#validate'][] = '_hel_tpm_form_validate_service_form';
+
   _hel_tpm_form_publish_service_action($form, $form_state);
+}
+
+/**
+ * Extra server-side validation for editing service nodes.
+ *
+ * @param array $form
+ *   The form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return void
+ */
+function _hel_tpm_form_validate_service_form(array &$form, FormStateInterface &$form_state): void {
+  // Check that age range is given, unless age group is selected. Not trying to
+  // validate, if the field `field_target_group` is missing.
+  if ($target_group = $form_state->getValue('field_target_group')) {
+    $age_groups = $target_group[0]['subform']['field_age_groups'][0]['value'] ?? NULL;
+    $age_from = $target_group[0]['subform']['field_age'][0]['from'] ?? NULL;
+    $age_to = $target_group[0]['subform']['field_age'][0]['to'] ?? NULL;
+
+    if (empty($age_groups) && (empty($age_from) || empty($age_to))) {
+      $form_state->setErrorByName(
+        "field_target_group][0][subform][field_age][0",
+        t('Setting an age range is mandatory, unless an age group is selected.')
+      );
+    }
+  }
 }
 
 /**

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1,4 +1,3 @@
-Xdebug: [Step Debug] Time-out connecting to debugging client, waited: 200 ms. Tried: 192.168.1.55:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(
 # Finnish translation of Pääkaupunkiseudun työllisyyspalvelumanuaali
 #
 msgid ""
@@ -1422,3 +1421,6 @@ msgstr "Julkaisemattomia muutoksia"
 
 msgid "Approve"
 msgstr "Hyväksy"
+
+msgid "Setting an age range is mandatory, unless an age group is selected."
+msgstr "Ikäväli on pakollinen kenttä, jos ikäryhmää ei ole annettu."


### PR DESCRIPTION
# TP-970: Require age group selection or setting age range

When editing service nodes, it's now required to fill either the _age groups_ or _age range_ field if the node is saved as _ready to published_ or _published_ state.

This PR contains both client side and server side validation for requiring those fields.

Before ending up to this implementation, tried to solve the issue by defining a custom constraint. However, there were some issues, e.g. the paragraph widget didn't highlight the correct fields.

**Actions necessary for applying the changes:**

drush cim
drush cr

**Testing instructions:**

* Log in.
* Create new or edit existing service.
* Make sure you can save it as a _draft_ without filling _age groups_ and _age range_ fields.
* Make sure that when saving it as _ready to publish_ or _published_, it is mandatory to fill either _age groups_ or _age range_ field.
* Try with another user that has different permissions.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
