### PR TITLE
Story/tp 973 required service specialist fields

### DIFF
--- a/config/sync/field.field.node.service.field_service_time_and_location.yml
+++ b/config/sync/field.field.node.service.field_service_time_and_location.yml
@@ -8,6 +8,10 @@ dependencies:
     - paragraphs.paragraphs_type.service_time_and_place
   module:
     - entity_reference_revisions
+    - require_on_publish
+third_party_settings:
+  require_on_publish:
+    require_on_publish: true
 id: node.service.field_service_time_and_location
 field_name: field_service_time_and_location
 entity_type: node

--- a/config/sync/field.field.paragraph.service_time_and_place.field_service_languages.yml
+++ b/config/sync/field.field.paragraph.service_time_and_place.field_service_languages.yml
@@ -8,6 +8,10 @@ dependencies:
     - paragraphs.paragraphs_type.service_time_and_place
   module:
     - entity_reference_revisions
+    - require_on_publish
+third_party_settings:
+  require_on_publish:
+    require_on_publish: true
 id: paragraph.service_time_and_place.field_service_languages
 field_name: field_service_languages
 entity_type: paragraph

--- a/public/modules/custom/service_manual_workflow/service_manual_workflow.module
+++ b/public/modules/custom/service_manual_workflow/service_manual_workflow.module
@@ -2,6 +2,7 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\content_moderation\Entity\ContentModerationStateInterface;
+use Drupal\field\FieldConfigInterface;
 use Drupal\service_manual_workflow\Event\ServiceModerationEvent;
 
 /**
@@ -78,14 +79,47 @@ function service_manual_workflow_entity_insert(EntityInterface $entity) {
 /**
  * Implements hook_require_on_publish_is_published_alter().
  */
-function service_manual_workflow_require_on_publish_is_published_alter(&$is_published, $entity, $operation) {
-  $entity_type = $entity->getEntityTYpe();
-  $publish_states = ['ready_to_publish', 'published'];
+function service_manual_workflow_require_on_publish_is_published_alter(&$is_published, &$entity, $operation) {
+  /** @var \Drupal\content_moderation\Entity\ContentModerationState $entity */
+  $entity_type = $entity->getEntityType();
   if ($entity_type->id() !== 'node') {
     return;
   }
+
+  $publish_states = ['ready_to_publish', 'published'];
   $moderation_state = $entity->moderation_state->value;
   $is_published = in_array($moderation_state, $publish_states);
+
+  // Allow saving a service node to `ready to publish` state without filling the
+  // `Specialist` fields which are required for specialist editors. The fields
+  // are still required before publishing the node.
+  if ($entity->bundle() === 'service' && $moderation_state === 'ready_to_publish') {
+    $required_specialist_fields = [
+      'field_service_req_speacialist',
+      'field_guidance_to_service',
+      'field_obligatoryness_freetext',
+      'field_obligatoryness',
+      'field_career_marking',
+      'field_statements_unemployment',
+      'field_statements',
+      'field_service_suits_job_search',
+    ];
+
+    /** @var \Drupal\Core\Field\FieldItemListInterface $field */
+    foreach ($entity->getFields() as $field) {
+      $field_config = $field->getFieldDefinition();
+      if (!($field_config instanceof FieldConfigInterface)) {
+        continue;
+      }
+      if (in_array($field->getName(), $required_specialist_fields)) {
+        // This setting is read at RequireOnPublish constraint's validate().
+        // The entity itself is not saved, so the change is not persistent.
+        // Setting the value to false means that validate() does not build
+        // constraint violation.
+        $field_config->setThirdPartySetting('require_on_publish', 'require_on_publish', FALSE);
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
# TP-973: Do not require specialist fields for ready to publish

This change allows specialist editors to save services to `ready to publish` state without filling the `Specialist` fields. This way the specialist editors can save the service as a "draft" without actually saving it as a draft, as that would confuse other editors.

The `Specialist` fields are still required before publishing the service.

As a separate issue, the service language is set required for publishing. However, there is an issue when the form validation tries to mark required empty fields. Some other paragraph fields are also affected, so this should be fixed with a separate task.

**Actions necessary for applying the changes:**

drush cim
drush cr

**Testing instructions:**
- [x] Log in as **specialist editor**.
- [x] Create a new **service**.
Make sure you can save the service:
- [x] as a draft without filling any of the fields under the **Specialist** tab.
- [x] as **ready to publish** without filling any of the fields under the **Specialist** tab.
- [x] as published and the required fields under the **Specialist** tab are now required.
Also make sure that when saving the service:
- [x] as **ready to publish**, adding **a place and time** is required.
- [x] as **published**, the language within that field is required.
- [x] Also use the normal editor role to save the service to check that it still works.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
