### PR TITLE
Fix group responsibility services view

### DIFF
--- a/config/sync/views.view.group_responsibility_services.yml
+++ b/config/sync/views.view.group_responsibility_services.yml
@@ -925,53 +925,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           use_tokens: 0
-        id:
-          id: id
-          table: groups_field_data
-          field: id
-          relationship: gid
-          group_type: group
-          admin_label: ''
-          entity_type: group
-          entity_field: id
-          plugin_id: numeric
-          operator: '!='
-          value:
-            min: ''
-            max: ''
-            value: '[current-page:url:args:value:1]'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          use_tokens: 1
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
# Fix group responsibility services view

There were an error while trying to get the group ID from the URL during ajax call. It was decided that the broken filter is not needed at least for now, so removing it.

**Actions necessary for applying the changes:**

drush cim
drush cr

**Testing instructions:**
- [x] Log in
- [x] Go to some group page and select the responsibility services tab (`/group/<ID>/group-responsibility-services`).
- [x] Try to use the view by using the filters and paging. Check that it works.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
