### PR TITLE
TP-970 Add additional error message for age groups

### DIFF
--- a/public/modules/custom/hel_tpm_forms/hel_tpm_forms.module
+++ b/public/modules/custom/hel_tpm_forms/hel_tpm_forms.module
@@ -174,8 +174,12 @@ function _hel_tpm_form_validate_service_form(array &$form, FormStateInterface &$
 
     if (empty($age_groups) && (empty($age_from) || empty($age_to))) {
       $form_state->setErrorByName(
+        "field_target_group][0][subform][field_age_groups",
+        t('Selecting an age group is mandatory, unless the age range is set.')
+      );
+      $form_state->setErrorByName(
         "field_target_group][0][subform][field_age][0",
-        t('Setting an age range is mandatory, unless an age group is selected.')
+        t('Setting the age range is mandatory, unless an age group is selected.')
       );
     }
   }

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1443,5 +1443,8 @@ msgstr "Sisällön lisätiedot"
 msgid "All entities"
 msgstr "Kaikki tiedot"
 
-msgid "Setting an age range is mandatory, unless an age group is selected."
-msgstr "Ikäväli on pakollinen kenttä, jos ikäryhmää ei ole annettu."
+msgid "Selecting an age group is mandatory, unless the age range is set."
+msgstr "Ikäryhmävalinta on pakollinen, jos ikäväliä ei ole määritelty."
+
+msgid "Setting the age range is mandatory, unless an age group is selected."
+msgstr "Ikäväli on pakollinen kenttä, jos ikäryhmää ei ole valittu."


### PR DESCRIPTION
# TP-970: Add additional error message for age groups

As requested, add additional error message when saving a service and the age groups and age range fields are not filled.

**Actions necessary for applying the changes:**

drush cr

**Testing instructions:**
- [x] Log in
- [x] Create new or edit existing service.
- [x] Make sure you can save it as a draft without filling age groups and age range fields.
- [x] Make sure that when saving it as ready to publish or published, it is mandatory to fill either age groups or age range field.
- [x] **When the age groups and age range fields are empty, there is error for both fields, i.e. both fields have red error marker around them.**

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
