### PR TITLE
TP-990 added rtb notification sending when moving service from published and outdated to ready to publish state

### DIFF
--- a/public/modules/custom/service_manual_workflow/src/EventSubscriber/ServiceStateChangedNotificationSubscriber.php
+++ b/public/modules/custom/service_manual_workflow/src/EventSubscriber/ServiceStateChangedNotificationSubscriber.php
@@ -224,6 +224,8 @@ class ServiceStateChangedNotificationSubscriber implements EventSubscriberInterf
    */
   public static function getSubscribedEvents() {
     return [
+      'service_manual_workflow.published.to.ready_to_publish' => ['draftToReadyToPublish'],
+      'service_manual_workflow.outdated.to.ready_to_publish' => ['draftToReadyToPublish'],
       'service_manual_workflow.draft.to.ready_to_publish' => ['draftToReadyToPublish'],
       'service_manual_workflow.ready_to_publish.to.published' => ['readyToPublishToPublished']
     ];


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush cr


**Testing instructions:**
- [x] Login as subgroup editor
- [x] Move published service  to ready to publish 
- [x] Confirm either municipality updatee or parent group admins get notification from service
- [x] Move service to published -> outdated -> ready to publish
- [x] Confirm either municipality updatee or parent group admins get notification from service

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
