### PR TITLE
TP-951 Add contact info view permission for specialists

### DIFF
--- a/config/sync/user.role.specialist.yml
+++ b/config/sync/user.role.specialist.yml
@@ -25,6 +25,7 @@ permissions:
   - 'view field_age'
   - 'view field_archiving_guide'
   - 'view field_career_marking'
+  - 'view field_contact_info'
   - 'view field_contact_info_internal'
   - 'view field_exceptions'
   - 'view field_guidance_to_service'


### PR DESCRIPTION
# TP-951: Add missing contact info view permission for specialist roles

**Actions necessary for applying the changes:**

drush cim
drush cr

**Testing instructions:**

- [x] Login as a content editor and make sure some new or existing service has _Private contact information_ info. (This can be found from the _Additional information_ tab.)
- [x] Next, log in as a specialist who has the right to see the service.
- [x] Go to the service's "Internal guide" page. Make sure you can see the _Private contact information_.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.