### PR TITLE
TP-1026: Uninstall Contextual links module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -23,7 +23,6 @@ module:
   content_moderation: 0
   context: 0
   context_ui: 0
-  contextual: 0
   csv_serialization: 0
   ctools: 0
   date_recur: 0


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush cim
drush cr

**Testing instructions:**
- [x] Login as admin user and check that contextual links are gone. There is no "Edit" button at the admin menu top-right corner and there are no "pen icons" when hovering over blocks and menus.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles