### PR TITLE
TP-1036 raised autologout limit to 8 hours and confirmation popup to 1m

### DIFF
--- a/config/sync/autologout.settings.yml
+++ b/config/sync/autologout.settings.yml
@@ -2,9 +2,9 @@ _core:
   default_config_hash: kwGGKvKSU7cPTEgTMWrbW0o9Jwe6FSDmpgdUWmIXCdg
 langcode: fi
 enabled: true
-timeout: 3600
+timeout: 28800
 max_timeout: 172800
-padding: 20
+padding: 60
 logout_regardless_of_activity: false
 no_individual_logout_threshold: false
 role_logout: false


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Login and confirm autologout timeout is 28800 seconds and timeout padding 60 seconds
- [x] Check the content

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [x] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
