### PR TITLE
TP-1035 Change municipality labels

### DIFF
--- a/config/sync/field.field.paragraph.target_group.field_target_group_municipality.yml
+++ b/config/sync/field.field.paragraph.target_group.field_target_group_municipality.yml
@@ -19,7 +19,7 @@ id: paragraph.target_group.field_target_group_municipality
 field_name: field_target_group_municipality
 entity_type: paragraph
 bundle: target_group
-label: 'Kunta:'
+label: 'Kotikunta:'
 description: ''
 required: false
 translatable: true

--- a/config/sync/language/en/field.field.paragraph.target_group.field_target_group_municipality.yml
+++ b/config/sync/language/en/field.field.paragraph.target_group.field_target_group_municipality.yml
@@ -1,1 +1,1 @@
-label: 'Municipality:'
+label: 'Municipality of residence:'

--- a/config/sync/language/en/views.view.solr_service_search.yml
+++ b/config/sync/language/en/views.view.solr_service_search.yml
@@ -28,6 +28,8 @@ display:
         field_free_service:
           group_info:
             label: 'Service is chargeable'
+          expose:
+            description: ''
         field_age_groups:
           expose:
             label: 'Target groups age'
@@ -39,4 +41,4 @@ display:
             label: Implementation
         field_municipality:
           expose:
-            label: Municipality
+            label: 'Municipality of residence'

--- a/config/sync/language/sv/field.field.paragraph.target_group.field_target_group_municipality.yml
+++ b/config/sync/language/sv/field.field.paragraph.target_group.field_target_group_municipality.yml
@@ -1,1 +1,1 @@
-label: 'Kommun:'
+label: 'Hemkommun:'

--- a/config/sync/language/sv/views.view.solr_service_search.yml
+++ b/config/sync/language/sv/views.view.solr_service_search.yml
@@ -17,6 +17,8 @@ display:
         field_free_service:
           group_info:
             label: 'Tjänsten är betald'
+          expose:
+            description: ''
         field_service_set:
           expose:
             label: 'Tjänstekategori:'
@@ -37,4 +39,4 @@ display:
             label: Genomförande
         field_municipality:
           expose:
-            label: Kommun
+            label: Hemkommun

--- a/config/sync/views.view.solr_service_search.yml
+++ b/config/sync/views.view.solr_service_search.yml
@@ -638,7 +638,7 @@ display:
           exposed: true
           expose:
             operator_id: field_municipality_op
-            label: Kunta
+            label: Kotikunta
             description: ''
             use_operator: false
             operator: field_municipality_op


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush cim
drush cr

**Testing instructions:**
- [ ] Go to the service edit form and check that the label for municipality selection is changed for "Municipality of residence" (with translations).
- [ ] Go to the search form and check that the label for municipality filter is also changed to "Municipality of residence" (with translations).
- [ ] Check that the search still works.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
