### PR TITLE
TP-1040 Raise logout dialog respond time

### DIFF
--- a/config/sync/autologout.settings.yml
+++ b/config/sync/autologout.settings.yml
@@ -4,7 +4,7 @@ langcode: fi
 enabled: true
 timeout: 28800
 max_timeout: 172800
-padding: 60
+padding: 120
 logout_regardless_of_activity: false
 no_individual_logout_threshold: false
 role_logout: false


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush cim
drush cr

**Testing instructions:**
- [x] Login as admin user and go to some user's edit page.
- [x] Temporarily change the user's "Your current logout threshold" time to minimun 60 seconds.
- [x] Login as that user and do nothing for 60 seconds.
- [x] The autologout dialog appears and stays for 2 minutes.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
