### PR TITLE
TP-1093 Do not allow content admin view for specialist users

### DIFF
--- a/config/sync/views.view.maintenance_and_administration.yml
+++ b/config/sync/views.view.maintenance_and_administration.yml
@@ -6,7 +6,6 @@ dependencies:
     - user.role.admin
     - user.role.editor
     - user.role.root
-    - user.role.specialist
     - user.role.specialist_editor
   module:
     - group
@@ -203,7 +202,6 @@ display:
             root: root
             admin: admin
             editor: editor
-            specialist: specialist
             specialist_editor: specialist_editor
       cache:
         type: tag


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush cim
drush cr

**Testing instructions:**
- [x] Login as specialist user (without other roles)
- [x] Check that there is no "Administration and content management" link at the left sidebar.
- [x] Check that the user does not have access to the corresponding content management page.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
