### PR TITLE
TP-1155 Service place language not required

### DIFF
--- a/config/sync/field.field.paragraph.service_language.field_language.yml
+++ b/config/sync/field.field.paragraph.service_language.field_language.yml
@@ -6,12 +6,6 @@ dependencies:
     - field.storage.paragraph.field_language
     - paragraphs.paragraphs_type.service_language
     - taxonomy.vocabulary.service_languages
-  module:
-    - require_on_publish
-third_party_settings:
-  require_on_publish:
-    require_on_publish: true
-    warn_on_empty: false
 id: paragraph.service_language.field_language
 field_name: field_language
 entity_type: paragraph

--- a/config/sync/field.field.paragraph.service_time_and_place.field_service_languages.yml
+++ b/config/sync/field.field.paragraph.service_time_and_place.field_service_languages.yml
@@ -8,10 +8,6 @@ dependencies:
     - paragraphs.paragraphs_type.service_time_and_place
   module:
     - entity_reference_revisions
-    - require_on_publish
-third_party_settings:
-  require_on_publish:
-    require_on_publish: true
 id: paragraph.service_time_and_place.field_service_languages
 field_name: field_service_languages
 entity_type: paragraph
@@ -35,8 +31,32 @@ settings:
       content:
         weight: 9
         enabled: false
-      content_list_lift_header_icon:
-        weight: 10
+      content_card_lift:
+        weight: 20
+        enabled: false
+      content_link_file:
+        weight: 21
+        enabled: false
+      content_link_file_guide:
+        weight: 22
+        enabled: false
+      full_width_card_lift:
+        weight: 23
+        enabled: false
+      header_description_link:
+        weight: 24
+        enabled: false
+      link:
+        weight: 25
+        enabled: false
+      long_text_field_with_toolbar:
+        weight: 26
+        enabled: false
+      municipality_guide:
+        weight: 27
+        enabled: false
+      quick_link:
+        weight: 28
         enabled: false
       service_language:
         weight: 11
@@ -49,5 +69,8 @@ settings:
         enabled: false
       target_group:
         weight: 14
+        enabled: false
+      url_and_file:
+        weight: 32
         enabled: false
 field_type: entity_reference_revisions


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

`Drush cim`

Service time and place language is not required in any publishing mode.


**Testing instructions:**
- [ ] Login and create service
- [ ] Dont fill service place and time paragraph's language field and make sure saving as draft is possible
- [ ] Edit the same service 
- [ ] Change to published and fill required fields (don't fill the service time and place paragraph's langueage field )

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
