### PR TITLE
TP-1171 Change age filter's age ranges

### DIFF
--- a/config/sync/views.view.solr_service_search.yml
+++ b/config/sync/views.view.solr_service_search.yml
@@ -511,8 +511,8 @@ display:
           operator: or
           value:
             all: all
-            16-30: 16-30
-            31-54: 31-54
+            16-29: 16-29
+            30-54: 30-54
             55-70: 55-70
           group: 1
           exposed: true

--- a/public/modules/custom/hel_tpm_search/src/Plugin/views/filter/AgeGroups.php
+++ b/public/modules/custom/hel_tpm_search/src/Plugin/views/filter/AgeGroups.php
@@ -75,8 +75,8 @@ class AgeGroups extends ManyToOne {
    */
   protected function generateOptions(): array {
     return [
-      '16-30' => t("16–30-year-olds"),
-      '31-54' => t("31–54-year-olds"),
+      '16-29' => t("16–29-year-olds"),
+      '30-54' => t("30–54-year-olds"),
       '55-70' => t("55–70-year-olds"),
     ];
   }

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1458,11 +1458,11 @@ msgstr "Lisää olemassaolevia käyttäjiä"
 msgid "Invite new users"
 msgstr "Kutsu uusia käyttäjiä"
 
-msgid "16–30-year-olds"
-msgstr "16–30-vuotiaat"
+msgid "16–29-year-olds"
+msgstr "16–29-vuotiaat"
 
-msgid "31–54-year-olds"
-msgstr "31–54-vuotiaat"
+msgid "30–54-year-olds"
+msgstr "30–54-vuotiaat"
 
 msgid "55–70-year-olds"
 msgstr "55–70-vuotiaat"

--- a/translations/sv-interface-translations.po
+++ b/translations/sv-interface-translations.po
@@ -826,11 +826,11 @@ msgstr "Lägg till befintliga användare"
 msgid "Invite new users"
 msgstr "Bjud in nya användare"
 
-msgid "16–30-year-olds"
-msgstr "16–30-åringar"
+msgid "16–29-year-olds"
+msgstr "16–29-åringar"
 
-msgid "31–54-year-olds"
-msgstr "31–54-åringar"
+msgid "30–54-year-olds"
+msgstr "30–54-åringar"
 
 msgid "55–70-year-olds"
 msgstr "55–70-åringar"


### PR DESCRIPTION
**Actions necessary for applying the changes:**

drush deploy

**Testing instructions:**
- [x] Go to the search page and make sure the age filter has the updated "16–29-year-olds" value.
- [x] Do a search with that and check the results.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
