### PR TITLE
TP-965 Show account status at group members list

### DIFF
--- a/config/sync/language/en/views.view.group_members.yml
+++ b/config/sync/language/en/views.view.group_members.yml
@@ -10,50 +10,35 @@ display:
       fields:
         name:
           label: User
-          separator: ', '
         group_roles:
           label: Roles
-          separator: ', '
         view_group_content:
-          admin_label: 'View member link'
           text: 'View member'
         edit_group_content:
-          admin_label: 'Edit member link'
           text: 'Edit member'
         delete_group_content:
-          admin_label: 'Remove member link'
           text: 'Remove member'
         dropbutton:
           label: Operations
+        status:
+          label: Status
+          settings:
+            format_custom_false: Blocked
+            format_custom_true: Active
       pager:
         options:
           tags:
-            next: ››
-            previous: ‹‹
             first: '« First'
             last: 'Last »'
-          expose:
-            items_per_page_label: 'Items per page'
-            items_per_page_options_all_label: '- All -'
-            offset_label: Offset
+          expose: {  }
       exposed_form:
-        options:
-          submit_button: Apply
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+        options: {  }
       empty:
-        area_text_custom:
-          content: 'No members available.'
+        area_text_custom: {  }
       arguments:
         gid:
-          exception:
-            title: All
-          title: '{{ arguments.gid|placeholder }} members'
-    display_title: Master
+          exception: {  }
   page_1:
-    display_title: Page
     display_options:
       menu:
         title: Members

--- a/config/sync/language/sv/views.view.group_members.yml
+++ b/config/sync/language/sv/views.view.group_members.yml
@@ -10,23 +10,21 @@ display:
       fields:
         name:
           label: Användare
-          separator: ', '
         group_roles:
           label: Roll
-          separator: ', '
-        view_group_content:
-          text: 'Näytä jäsen'
-        edit_group_content:
-          text: 'Muokkaa jäsentä'
-        delete_group_content:
-          text: 'Poista jäsen'
+        view_group_content: {  }
+        edit_group_content: {  }
+        delete_group_content: {  }
         dropbutton:
           label: Funktioner
+        status:
+          label: Status
+          settings:
+            format_custom_false: Spärrad
+            format_custom_true: Aktiv
       pager:
         options:
           tags:
-            next: ››
-            previous: ‹‹
             first: '« Första'
             last: 'Sista »'
           expose:
@@ -50,4 +48,3 @@ display:
     display_options:
       menu:
         title: Medlemskap
-label: 'Ryhmien jäsenyydet'

--- a/config/sync/user.role.admin.yml
+++ b/config/sync/user.role.admin.yml
@@ -56,6 +56,7 @@ permissions:
   - 'access contact info overview'
   - 'access content overview'
   - 'access entity_browser entity browser pages'
+  - 'access extra member info if group admin'
   - 'access flagging collection overview'
   - 'access group overview'
   - 'access htg entity group field autocomplete widget'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -22,6 +22,7 @@ dependencies:
     - flag
     - flag_lists
     - hel_tpm_contact_info
+    - hel_tpm_group
     - media
     - node
     - paragraphs
@@ -35,6 +36,7 @@ is_admin: null
 permissions:
   - 'access content'
   - 'access entity_browser entity browser pages'
+  - 'access extra member info if group admin'
   - 'access shortcuts'
   - 'access user profiles'
   - 'add flag lists'

--- a/config/sync/user.role.specialist_editor.yml
+++ b/config/sync/user.role.specialist_editor.yml
@@ -9,12 +9,14 @@ dependencies:
     - file
     - hel_tpm_contact_info
     - hel_tpm_general
+    - hel_tpm_group
     - paragraphs_type_permissions
 id: specialist_editor
 label: 'Specialist editor'
 weight: 6
 is_admin: null
 permissions:
+  - 'access extra member info if group admin'
   - 'access internal service fields'
   - 'create contact info'
   - 'create field_age'

--- a/config/sync/views.view.group_members.yml
+++ b/config/sync/views.view.group_members.yml
@@ -91,6 +91,73 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          relationship: gc__user
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: status
+          plugin_id: field
+          label: Tila
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Suljettu
+            format_custom_true: Voimassa
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         group_roles:
           id: group_roles
           table: group_content__group_roles

--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.module
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.module
@@ -5,14 +5,57 @@
  * Primary module hooks for hel_tpm_group module.
  */
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupRelationshipInterface;
 use Drupal\group\Entity\GroupRole;
 use Drupal\hel_tpm_group\Event\GroupMembershipChanged;
 use Drupal\hel_tpm_group\Event\GroupSiteWideRoleChanged;
 use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_entity_field_access().
+ *
+ * Allows group admins to see members' status field.
+ */
+function hel_tpm_group_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL): AccessResultInterface {
+  // Don't interfere if not trying to view user's status field.
+  if (empty($field_definition->getTargetEntityTypeId())
+    || $field_definition->getTargetEntityTypeId() != 'user'
+    || $operation != 'view'
+    || $field_definition->getName() != 'status') {
+    return AccessResult::neutral();
+  }
+  // Don't interfere if group is not specified with route parameter.
+  $route_match = \Drupal::routeMatch();
+  $parameters = $route_match->getParameters();
+  if (!$parameters->has('group')) {
+    return AccessResult::neutral();
+  }
+  // Don't interfere if parameter is not a group.
+  $group = $parameters->get('group');
+  if (!$group instanceof GroupInterface) {
+    return AccessResult::neutral();
+  }
+  // Don't interfere if user is not a member of the group.
+  if (!$membership = $group->getMember($account)) {
+    return AccessResult::neutral();
+  }
+  // Allow group admins to view the user status field if the user also has
+  // correct permission.
+  $roles = $membership->getRoles();
+  if (array_key_exists('organisation-administrator', $roles)
+    || array_key_exists('service_provider-group_admin', $roles)) {
+    return AccessResult::allowedIfHasPermission($account, 'access extra member info if group admin')->cachePerPermissions();
+  }
+  return AccessResult::neutral();
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().

--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.permissions.yml
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.permissions.yml
@@ -1,3 +1,6 @@
 access htg entity group field autocomplete widget:
   title: 'Access htg entity group field autocomplete widget'
   description: 'Give user access to view and edit fields with htg entity group field autocomplete widget'
+access extra member info if group admin:
+  title: 'Access extra member information in groups the user administer'
+  description: 'Allows the group admin to see extra information (e.g. user status) of the group members.'


### PR DESCRIPTION
Adds account status column to group members lists. Allows group admins to see the members' status field (which is not allowed by default).

**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
- [x] Log in as a user with admin role.
- [x] Go to some group's member list page.
- [x] Make sure there is a status column.
- [x] Log in as user who does not have an admin role, but is a group admin to a **organisation** group.
- [x] Go to the group's member list page.
- [x] Make sure there is a status column.
- [x] Log in as user who does not have an admin role, but is a group admin to a **service provider** group.
- [x] Go to the group's member list page.
- [x] Make sure there is a status column.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
