### PR TITLE
TP-1229 Adjust date place text logic

### DIFF
--- a/public/modules/custom/hel_tpm_general/src/Plugin/Field/FieldFormatter/TimeAndPlaceFormatter.php
+++ b/public/modules/custom/hel_tpm_general/src/Plugin/Field/FieldFormatter/TimeAndPlaceFormatter.php
@@ -23,10 +23,14 @@ final class TimeAndPlaceFormatter extends EntityReferenceEntityFormatter {
    */
   public function viewElements(FieldItemListInterface $items, $langcode): array {
     foreach ($this->getEntitiesToView($items, $langcode) as $delta => $entity) {
+
       if (!$entity->hasField('field_service_location')) {
         continue;
       }
-      if ($entity->get('field_service_location')->isEmpty()) {
+      if (!$entity->hasField('field_dates')) {
+        continue;
+      }
+      if ($entity->get('field_service_location')->isEmpty() && $entity->get('field_dates')->isEmpty())  {
         $items->removeItem($delta);
       }
     }

--- a/public/modules/custom/hel_tpm_general/src/Plugin/Field/FieldFormatter/TimeAndPlaceFormatter.php
+++ b/public/modules/custom/hel_tpm_general/src/Plugin/Field/FieldFormatter/TimeAndPlaceFormatter.php
@@ -23,7 +23,6 @@ final class TimeAndPlaceFormatter extends EntityReferenceEntityFormatter {
    */
   public function viewElements(FieldItemListInterface $items, $langcode): array {
     foreach ($this->getEntitiesToView($items, $langcode) as $delta => $entity) {
-
       if (!$entity->hasField('field_service_location')) {
         continue;
       }

--- a/public/themes/custom/palvelumanuaali/templates/paragraphs/paragraph--service-time-and-place.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/paragraphs/paragraph--service-time-and-place.html.twig
@@ -46,7 +46,22 @@
     {% if content.field_separate_time[0]['#markup'] == 1 %}
       {{content|without('field_separate_time','field_dates')}}
     {% else %}
-      {{content|without('field_separate_time')}}
+
+      {% if content.field_service_location[0]|default(null) %}
+        {{content|without('field_separate_time')}}
+      {% else %}
+        {{content|without('field_separate_time')}}
+        <article {{ bem("node",'service-location','',['flex-wrap']) }}>
+          {% include "@atoms/text/headings/_heading.twig" with {
+            "heading_level": 4,
+            "heading": "No location has been specified."|t,
+            "heading_modifiers": "service-location",
+            "heading_link_attributes": {
+              'rel': 'bookmark'
+            }
+          } %}
+        </article>
+      {% endif %}
     {% endif %}
 
   </div>

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1484,3 +1484,6 @@ msgstr "Kotikunnalla ei merkitystä"
 
 msgid "Home municipality"
 msgstr "Kotikunta"
+
+msgid "No location has been specified."
+msgstr "Toimipaikkaa ei määritetty."

--- a/translations/sv-interface-translations.po
+++ b/translations/sv-interface-translations.po
@@ -852,3 +852,6 @@ msgstr "Hemkommun spelar ingen roll"
 
 msgid "Home municipality"
 msgstr "Hemkommun"
+
+msgid "No location has been specified."
+msgstr "Ingen plats har angetts."


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

```
lando drush -y locale:import fi ../translations/fi-interface-translations.po
lando drush -y locale:import sv ../translations/sv-interface-translations.po
lando drush cr
lando drush deploy
```
Fixes issue where date and place element won't be shown when location is not chosen.
If location or date is chosen, the box should be displayed


**Testing instructions:**
- [x] login
- [x] Check service without chosen place (second page of the service form). The service date and place should have text "No location has been specified." 
- [x] Edit said service and remove the date and check "the date is to be specified" boolean. Save. 
- [x] No date & element should be shown
- [x] Edit the service and Add date and location. Save.
- [x] Both should be displayed correctly

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
