### PR TITLE
TP-1223 add most common excel filetypes to internal files and file fi…

### DIFF
--- a/config/sync/field.field.node.service.field_internal_files.yml
+++ b/config/sync/field.field.node.service.field_internal_files.yml
@@ -21,7 +21,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'docx doc pdf ppt pptx jpg png mp4'
+  file_extensions: 'docx doc pdf ppt pptx jpg png mp4 xls xlsx'
   max_filesize: 50MB
   description_field: false
 field_type: file

--- a/config/sync/field.field.paragraph.url_and_file.field_file.yml
+++ b/config/sync/field.field.paragraph.url_and_file.field_file.yml
@@ -21,7 +21,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'docx doc pdf ppt pptx jpg png mp4'
+  file_extensions: 'docx doc pdf ppt pptx jpg png mp4 xls xlsx'
   max_filesize: '50 MB'
   description_field: false
 field_type: file


### PR DESCRIPTION
…elds

**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

`Drush deploy`
Adds two most common excel file types .xls and .xlsx to internal file field.

**Testing instructions:**
- [x] Login and edit service 
- [x] go to third page and confirm that both "asiakas" and "asiantuntija" file fields support .xls and .xlsx

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
