### PR TITLE
TP-1260 Require field_responsible_updatee on publish

### DIFF
--- a/config/sync/field.field.node.service.field_responsible_updatee.yml
+++ b/config/sync/field.field.node.service.field_responsible_updatee.yml
@@ -5,6 +5,11 @@ dependencies:
   config:
     - field.storage.node.field_responsible_updatee
     - node.type.service
+  module:
+    - require_on_publish
+third_party_settings:
+  require_on_publish:
+    require_on_publish: true
 id: node.service.field_responsible_updatee
 field_name: field_responsible_updatee
 entity_type: node

--- a/public/modules/custom/service_manual_workflow/service_manual_workflow.module
+++ b/public/modules/custom/service_manual_workflow/service_manual_workflow.module
@@ -88,11 +88,15 @@ function service_manual_workflow_require_on_publish_is_published_alter(&$is_publ
   $moderation_state = $entity->moderation_state->value;
   $is_published = in_array($moderation_state, $publish_states);
 
-  // Allow saving a service node to `ready to publish` state without filling the
-  // `Specialist` fields which are required for specialist editors. The fields
-  // are still required before publishing the node.
+  // Allow saving a service node to `ready to publish` state without e.g.
+  // filling the `Specialist` fields which are required for specialist editors.
+  // The fields are still required before publishing the node.
+  //
+  // @todo Consider replacing the require_on_publish module with a custom
+  // module. As emphasized by this workaround, there is a need for separate
+  // "require on publish" and "require on publish and ready to publish" states.
   if ($entity->bundle() === 'service' && $moderation_state === 'ready_to_publish') {
-    $required_specialist_fields = [
+    $fields_not_required_on_ready_to_publish = [
       'field_service_req_speacialist',
       'field_service_coordination',
       'field_obligatoryness_freetext',
@@ -101,6 +105,7 @@ function service_manual_workflow_require_on_publish_is_published_alter(&$is_publ
       'field_statements_unemployment',
       'field_statements',
       'field_service_suits_job_search',
+      'field_responsible_updatee',
     ];
 
     /** @var \Drupal\Core\Field\FieldItemListInterface $field */
@@ -109,7 +114,7 @@ function service_manual_workflow_require_on_publish_is_published_alter(&$is_publ
       if (!($field_config instanceof FieldConfigInterface)) {
         continue;
       }
-      if (in_array($field->getName(), $required_specialist_fields)) {
+      if (in_array($field->getName(), $fields_not_required_on_ready_to_publish)) {
         // This setting is read at RequireOnPublish constraint's validate().
         // The entity itself is not saved, so the change is not persistent.
         // Setting the value to false means that validate() does not build


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
- [x] Check that it's possible to save a service as _draft_ without filling the municipality user.
- [x] Check that it's possible to save a service as _ready to publish_ without filling the municipality user.
- [x] Check that it's required to fill the municipality user field when saving as _published_.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
