### PR TITLE
TP-1176 Exclude analytics from admin users and user pages

### DIFF
--- a/public/themes/custom/palvelumanuaali/palvelumanuaali.libraries.yml
+++ b/public/themes/custom/palvelumanuaali/palvelumanuaali.libraries.yml
@@ -7,7 +7,6 @@ global:
     js/breadcrumbs.js: {}
     js/header.js: {}
     dist/js/02-molecules/small-message/small-message.js: {}
-    js/matomo.js: {}
   dependencies:
     - core/popperjs
     - core/jquery
@@ -20,6 +19,14 @@ main-menu:
     dist/js/02-molecules/menus/main-menu/main-menu.js: {}
   dependencies:
     - core/drupal
+
+analytics:
+  js:
+    js/matomo.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - eu_cookie_compliance/eu_cookie_compliance
 
 search-filters:
   js:

--- a/public/themes/custom/palvelumanuaali/palvelumanuaali.theme
+++ b/public/themes/custom/palvelumanuaali/palvelumanuaali.theme
@@ -211,7 +211,6 @@ function palvelumanuaali_theme_suggestions_form_element_alter(array &$suggestion
   }
 }
 
-
 /**
  * @param array $suggestions
  * @param array $variables
@@ -278,7 +277,6 @@ function palvelumanuaali_theme_suggestions_taxonomy_term_alter(array &$suggestio
   $suggestions[] = 'taxonomy_term__' . $term->bundle() . '__' . $sanitized_view_mode;
   $suggestions[] = 'taxonomy_term__' . $term->id() . '__' . $sanitized_view_mode;
 }
-
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
@@ -355,6 +353,36 @@ function palvelumanuaali_theme_suggestions_fieldset_alter(array &$suggestions, a
   }
 }
 
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function palvelumanuaali_page_attachments_alter(array &$attachments) {
+  _palvelumanuaali_attach_analytics($attachments);
+}
+
+/**
+ * Attach analytics to page if conditions are met.
+ *
+ * @param array $attachments
+ *   Array of all attachments provided by hook_page_attachments().
+ *
+ * @return void
+ *   Void.
+ */
+function _palvelumanuaali_attach_analytics(array &$attachments) {
+  // Attach analytics only when user does not have admin or root role and the
+  // path is not excluded with a path pattern.
+  $roles = \Drupal::currentUser()->getRoles();
+  if (in_array('admin', $roles) || in_array('root', $roles)) {
+    return;
+  }
+  $path = \Drupal::service('path.current')->getPath();
+  $exclude_pattern = "/admin/*\n/user/*";
+  if (\Drupal::service('path.matcher')->matchPath($path, $exclude_pattern)) {
+    return;
+  }
+  $attachments['#attached']['library'][] = 'palvelumanuaali/analytics';
+}
 
 /**
  * Implements hook_form_alter().


### PR DESCRIPTION
**Actions necessary for applying the changes:**

drush deploy

**Testing instructions:**
When checking the script, try to find `matomo.js` from source.
- [x] Login as admin user.
- [x] Check that the script is not present with any page (e.g. services, admin pages, user profile).
- [x] Login as non-admin user.
- [x] Check that the script is present at service pages, search page & node edit forms.
- [x] Check that the script is not present at user profile pages.
- [x] Logout.
- [x] Check that the script is present at service pages & search page.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
