### PR TITLE
TP-1270 Log out specialists after two weeks of inactivity

### DIFF
--- a/config/sync/autologout.role.specialist.yml
+++ b/config/sync/autologout.role.specialist.yml
@@ -1,3 +1,3 @@
-enabled: false
-timeout: null
+enabled: true
+timeout: 1209600
 url: ''

--- a/config/sync/autologout.settings.yml
+++ b/config/sync/autologout.settings.yml
@@ -3,12 +3,12 @@ _core:
 langcode: fi
 enabled: true
 timeout: 28800
-max_timeout: 172800
+max_timeout: 1209600
 padding: 120
 logout_regardless_of_activity: false
-no_individual_logout_threshold: false
-role_logout: false
-role_logout_max: false
+no_individual_logout_threshold: true
+role_logout: true
+role_logout_max: true
 redirect_url: /user/login
 no_dialog: false
 message: 'Your session is about to expire. Do you want to reset it?'


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
- [x] Login as non-specialist user.
- [x] Set breakpoint to AutologoutSubscriber's row 169.
- [x] Refresh the page.
- [x] Using the breakpoint check that $timeout has the default value of 28800.
- [x] Login as specialist user.
- [x] Refresh the page and check that the same variable has now value 1209600 (meaning two weeks).

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
