### PR TITLE
Task/tp 1322 prevent messages to disabled accounts

### DIFF
--- a/public/modules/custom/hel_tpm_group/src/Plugin/QueueWorker/ServiceMissingUpdateesQueue.php
+++ b/public/modules/custom/hel_tpm_group/src/Plugin/QueueWorker/ServiceMissingUpdateesQueue.php
@@ -145,7 +145,7 @@ final class ServiceMissingUpdateesQueue extends QueueWorkerBase implements Conta
    * @return array|null
    *   Array of users or null.
    */
-  private function getUsersToNotify(GroupInterface $group) {
+  public static function getUsersToNotify(GroupInterface $group) {
     $roles = [
       'organisation-administrator',
       'service_provider-group_admin',
@@ -157,7 +157,10 @@ final class ServiceMissingUpdateesQueue extends QueueWorkerBase implements Conta
       return;
     }
     foreach ($memberships as $membership) {
-      $user = $membership->get('uid')->entity;
+      $user = $membership->get('entity_id')->entity;
+      if ($user->isBlocked()) {
+        continue;
+      }
       $members[$user->id()] = $user;
     }
 

--- a/public/modules/custom/hel_tpm_update_reminder/src/Plugin/QueueWorker/ServiceUpdateReminder.php
+++ b/public/modules/custom/hel_tpm_update_reminder/src/Plugin/QueueWorker/ServiceUpdateReminder.php
@@ -138,9 +138,6 @@ final class ServiceUpdateReminder extends QueueWorkerBase implements ContainerFa
       return FALSE;
     }
     $account = $service->get('field_service_provider_updatee')->entity;
-    if ($account->isBlocked()) {
-      return FALSE;
-    }
 
     $reminded = $this->sendMessage('hel_tpm_update_reminder_service', $account, $service);
     if ($reminded === TRUE) {

--- a/public/modules/custom/hel_tpm_update_reminder/src/Plugin/QueueWorker/ServiceUpdateReminder.php
+++ b/public/modules/custom/hel_tpm_update_reminder/src/Plugin/QueueWorker/ServiceUpdateReminder.php
@@ -138,9 +138,15 @@ final class ServiceUpdateReminder extends QueueWorkerBase implements ContainerFa
       return FALSE;
     }
     $account = $service->get('field_service_provider_updatee')->entity;
+    if ($account->isBlocked()) {
+      return FALSE;
+    }
 
-    UpdateReminderUtility::setMessagesSent($this->serviceId, $messageNumber);
-    return $this->sendMessage('hel_tpm_update_reminder_service', $account, $service);
+    $reminded = $this->sendMessage('hel_tpm_update_reminder_service', $account, $service);
+    if ($reminded === TRUE) {
+      UpdateReminderUtility::setMessagesSent($this->serviceId, $messageNumber);
+    }
+    return $reminded;
   }
 
   /**
@@ -204,6 +210,9 @@ final class ServiceUpdateReminder extends QueueWorkerBase implements ContainerFa
    * @throws \Drupal\message_notify\Exception\MessageNotifyException
    */
   protected function sendMessage(string $template, User $account, NodeInterface $service): bool {
+    if ($account->isBlocked()) {
+      return FALSE;
+    }
     $message = Message::create([
       'template' => $template,
       'uid' => $account->id(),

--- a/public/modules/custom/service_manual_workflow/src/ServiceNotificationTrait.php
+++ b/public/modules/custom/service_manual_workflow/src/ServiceNotificationTrait.php
@@ -28,7 +28,11 @@ trait ServiceNotificationTrait {
     if ($entity->field_responsible_updatee->isEmpty()) {
       return $user;
     }
-    $user[] = $entity->field_responsible_updatee->entity;
+    $responsible_user = $entity->field_responsible_updatee->entity;
+    if ($responsible_user->isBlocked()) {
+      return $user;
+    }
+    $user[] = $responsible_user;
     return $user;
   }
 

--- a/public/modules/custom/service_manual_workflow/src/ViewsData.php
+++ b/public/modules/custom/service_manual_workflow/src/ViewsData.php
@@ -6,11 +6,12 @@ use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\views\EntityViewsData;
 
 /**
  * {@inheritdoc}
  */
-class ViewsData {
+class ViewsData extends EntityViewsData {
   use StringTranslationTrait;
 
   /**

--- a/public/modules/custom/service_manual_workflow/src/ViewsData.php
+++ b/public/modules/custom/service_manual_workflow/src/ViewsData.php
@@ -6,12 +6,11 @@ use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\views\EntityViewsData;
 
 /**
  * {@inheritdoc}
  */
-class ViewsData extends EntityViewsData {
+class ViewsData {
   use StringTranslationTrait;
 
   /**

--- a/public/modules/custom/service_manual_workflow/tests/src/Traits/ServiceManualWorkflowTestTrait.php
+++ b/public/modules/custom/service_manual_workflow/tests/src/Traits/ServiceManualWorkflowTestTrait.php
@@ -16,7 +16,7 @@ trait ServiceManualWorkflowTestTrait {
    * @param array $values
    *   (optional) The values used to create the entity.
    *
-   * @return \Drupal\group\Entity\Group
+   * @return \Drupal\group\Entity\GroupInterface
    *   The created group entity.
    */
   protected function createGroup(array $values = []) {
@@ -26,7 +26,7 @@ trait ServiceManualWorkflowTestTrait {
     ]);
     $group->enforceIsNew();
     $storage->save($group);
-    return $group;
+    return $this->reloadEntity($group);
   }
 
   /**


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy && 
lando test public/modules/custom/hel_tpm_group/tests/src/Kernel/ServiceUpdateeMissingNotificationTest.php &&
lando test public/modules/custom/service_manual_workflow/tests/src/Kernel/ServiceStateChangedNotificationSubscriberTest.php

**Testing instructions:**
- [x] Confirm tests pass
- [x] Confirm services missing updater notifications work and wont send notifications for disabled accounts
- [x] Confirm service update reminders work and wont send notifications for disabled accounts
- [x] Do a custom code review and confirm there is no notifications sent for disabled accounts

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
