### PR TITLE
TP-537 User expiry

### DIFF
--- a/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_body.yml
@@ -14,4 +14,8 @@ content:
     weight: 0
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   partial_0: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_body.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_body.yml
@@ -1,0 +1,17 @@
+uuid: a4f7c9cd-8a86-47b8-b1d7-3a9ffda84f43
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_body
+    - message.template.hel_tpm_user_expiry_blocked
+id: message.hel_tpm_user_expiry_blocked.mail_body
+targetEntityType: message
+bundle: hel_tpm_user_expiry_blocked
+mode: mail_body
+content:
+  partial_1:
+    weight: 0
+    region: content
+hidden:
+  partial_0: true

--- a/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_subject.yml
@@ -14,4 +14,8 @@ content:
     weight: 0
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   partial_1: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_subject.yml
+++ b/config/sync/core.entity_view_display.message.hel_tpm_user_expiry_blocked.mail_subject.yml
@@ -1,0 +1,17 @@
+uuid: 2600b49a-33bb-483b-9993-3dd9ef765af4
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.message.mail_subject
+    - message.template.hel_tpm_user_expiry_blocked
+id: message.hel_tpm_user_expiry_blocked.mail_subject
+targetEntityType: message
+bundle: hel_tpm_user_expiry_blocked
+mode: mail_subject
+content:
+  partial_0:
+    weight: 0
+    region: content
+hidden:
+  partial_1: true

--- a/config/sync/language/fi/message.template.1st_user_account_expiry_reminder.yml
+++ b/config/sync/language/fi/message.template.1st_user_account_expiry_reminder.yml
@@ -1,7 +1,7 @@
 text:
   -
-    value: "<p>Your user account will expire in two weeks</p>\r\n"
-    format: filtered_html
+    value: 'Käyttäjätilisi vanhenee sivustolla [site:name]'
+    format: plain_text_format
   -
-    value: "<p>Hi,</p>\r\n\r\n<p>your user account [user:name] is about to expire due to inactivity. Please login within two weeks using the link below to keep the account active.</p>\r\n\r\n<p>[site:login-url]</p>\r\n\r\n<p>Best regards,</p>\r\n\r\n<p>Palvelumanuaali administration</p>\r\n"
-    format: filtered_html
+    value: "<p>Hei [user:display-name]</p>\r\n\r\n<p>Käyttäjätilisi sivustolla [site:name] on ollut epäaktiivinen yli 5 kuukautta. Tilisi vanhenee ja poistetaan, jos et käytä palvelua.</p>\r\n\r\n<p>Jos haluat jatkaa palvelun käyttöä, käy aktivoimassa tilisi. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href=\"[site:login-url]\">[site:login-url]</a></p>\r\n\r\n<p>Jos et enää käytä palvelua, voit jättää tämän viestin huomioimatta ja tilisi poistuu automaattisesti kahden viikon kuluttua.</p>\r\n\r\n<p>Ystävällisin terveisin<br />\r\n[site:name]-tiimi</p>\r\n\r\n<p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>\r\n"
+    format: email_html

--- a/config/sync/language/fi/message.template.2nd_user_account_expiry_reminder.yml
+++ b/config/sync/language/fi/message.template.2nd_user_account_expiry_reminder.yml
@@ -4,4 +4,4 @@ text:
     format: plain_text_format
   -
     value: "<p>Hei [user:display-name]</p>\r\n\r\n<p>Käyttäjätilisi sivustolla [site:name] on ollut epäaktiivinen yli 5 kuukautta. Tilisi vanhenee ja poistetaan, jos et käytä palvelua.</p>\r\n\r\n<p>Jos haluat jatkaa palvelun käyttöä, käy aktivoimassa tilisi. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href=\"[site:login-url]\">[site:login-url]</a></p>\r\n\r\n<p>Jos et enää käytä palvelua, voit jättää tämän viestin huomioimatta ja tilisi vanhenee automaattisesti 48 tunnin kuluttua.</p>\r\n\r\n<p>Ystävällisin terveisin<br />\r\n[site:name]-tiimi</p>\r\n\r\n<p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>\r\n"
-    format: filtered_html
+    format: email_html

--- a/config/sync/language/fi/message.template.2nd_user_account_expiry_reminder.yml
+++ b/config/sync/language/fi/message.template.2nd_user_account_expiry_reminder.yml
@@ -1,7 +1,7 @@
 text:
   -
-    value: "<p>Your user account is expiring in two days</p>\r\n"
-    format: filtered_html
+    value: "Käyttäjätilisi vanhenee sivustolla [site:name]\r\n"
+    format: plain_text_format
   -
-    value: "<p>Hi,</p>\r\n\r\n<p>your user account [user:name] is about to expire due to inactivity. Please login immediately using the link below.</p>\r\n\r\n<p>[site:login-url]</p>\r\n\r\n<p>Best regards,</p>\r\n\r\n<p>Palvelumanuaali administration</p>\r\n"
+    value: "<p>Hei [user:display-name]</p>\r\n\r\n<p>Käyttäjätilisi sivustolla [site:name] on ollut epäaktiivinen yli 5 kuukautta. Tilisi vanhenee ja poistetaan, jos et käytä palvelua.</p>\r\n\r\n<p>Jos haluat jatkaa palvelun käyttöä, käy aktivoimassa tilisi. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href=\"[site:login-url]\">[site:login-url]</a></p>\r\n\r\n<p>Jos et enää käytä palvelua, voit jättää tämän viestin huomioimatta ja tilisi vanhenee automaattisesti 48 tunnin kuluttua.</p>\r\n\r\n<p>Ystävällisin terveisin<br />\r\n[site:name]-tiimi</p>\r\n\r\n<p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>\r\n"
     format: filtered_html

--- a/config/sync/language/fi/message.template.hel_tpm_user_expiry_blocked.yml
+++ b/config/sync/language/fi/message.template.hel_tpm_user_expiry_blocked.yml
@@ -1,0 +1,7 @@
+text:
+  -
+    value: 'Henkilön [user:display-name] käyttäjätili on lukittu sivustolla [site:name]'
+    format: plain_text_format
+  -
+    value: '<p>Hei [user:display-name]</p><p>Käyttäjätilisi on suljettu sivustolla [site:name]. Jos tilin sulkeminen on ollut virheellinen, ole yhteydessä oman organisaatiosi pääkäyttäjään. Ylläpito voi uudelleen aktivoida suljetun tilin 30 päivän sisällä sen sulkemisesta.</p><p>Tämä viesti on lähetetty automaattisesti.</p><p>Ystävällisin terveisin<br>[site:name]-tiimi</p><p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>'
+    format: email_html

--- a/config/sync/message.template.1st_user_account_expiry_reminder.yml
+++ b/config/sync/message.template.1st_user_account_expiry_reminder.yml
@@ -3,17 +3,18 @@ langcode: fi
 status: true
 dependencies:
   config:
-    - filter.format.filtered_html
+    - filter.format.email_html
+    - filter.format.plain_text_format
 template: 1st_user_account_expiry_reminder
 label: '1st user account expiry reminder'
 description: ''
 text:
   -
-    value: "<p>Your user account will expire in two weeks</p>\r\n"
-    format: filtered_html
+    value: 'Käyttäjätilisi vanhenee sivustolla [site:name]'
+    format: plain_text_format
   -
-    value: "<p>Hi,</p>\r\n\r\n<p>your user account [user:name] is about to expire due to inactivity. Please login within two weeks using the link below to keep the account active.</p>\r\n\r\n<p>[site:login-url]</p>\r\n\r\n<p>Best regards,</p>\r\n\r\n<p>Palvelumanuaali administration</p>\r\n"
-    format: filtered_html
+    value: "<p>Hei [user:display-name]</p>\r\n\r\n<p>Käyttäjätilisi sivustolla [site:name] on ollut epäaktiivinen yli 5 kuukautta. Tilisi vanhenee ja poistetaan, jos et käytä palvelua.</p>\r\n\r\n<p>Jos haluat jatkaa palvelun käyttöä, käy aktivoimassa tilisi. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href=\"[site:login-url]\">[site:login-url]</a></p>\r\n\r\n<p>Jos et enää käytä palvelua, voit jättää tämän viestin huomioimatta ja tilisi poistuu automaattisesti kahden viikon kuluttua.</p>\r\n\r\n<p>Ystävällisin terveisin<br />\r\n[site:name]-tiimi</p>\r\n\r\n<p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>\r\n"
+    format: email_html
 settings:
   'token options':
     clear: false

--- a/config/sync/message.template.2nd_user_account_expiry_reminder.yml
+++ b/config/sync/message.template.2nd_user_account_expiry_reminder.yml
@@ -3,7 +3,7 @@ langcode: fi
 status: true
 dependencies:
   config:
-    - filter.format.filtered_html
+    - filter.format.email_html
     - filter.format.plain_text_format
 template: 2nd_user_account_expiry_reminder
 label: '2nd user account expiry reminder'
@@ -14,7 +14,7 @@ text:
     format: plain_text_format
   -
     value: "<p>Hei [user:display-name]</p>\r\n\r\n<p>Käyttäjätilisi sivustolla [site:name] on ollut epäaktiivinen yli 5 kuukautta. Tilisi vanhenee ja poistetaan, jos et käytä palvelua.</p>\r\n\r\n<p>Jos haluat jatkaa palvelun käyttöä, käy aktivoimassa tilisi. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href=\"[site:login-url]\">[site:login-url]</a></p>\r\n\r\n<p>Jos et enää käytä palvelua, voit jättää tämän viestin huomioimatta ja tilisi vanhenee automaattisesti 48 tunnin kuluttua.</p>\r\n\r\n<p>Ystävällisin terveisin<br />\r\n[site:name]-tiimi</p>\r\n\r\n<p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>\r\n"
-    format: filtered_html
+    format: email_html
 settings:
   'token options':
     clear: false

--- a/config/sync/message.template.2nd_user_account_expiry_reminder.yml
+++ b/config/sync/message.template.2nd_user_account_expiry_reminder.yml
@@ -4,15 +4,16 @@ status: true
 dependencies:
   config:
     - filter.format.filtered_html
+    - filter.format.plain_text_format
 template: 2nd_user_account_expiry_reminder
 label: '2nd user account expiry reminder'
 description: ''
 text:
   -
-    value: "<p>Your user account is expiring in two days</p>\r\n"
-    format: filtered_html
+    value: "Käyttäjätilisi vanhenee sivustolla [site:name]\r\n"
+    format: plain_text_format
   -
-    value: "<p>Hi,</p>\r\n\r\n<p>your user account [user:name] is about to expire due to inactivity. Please login immediately using the link below.</p>\r\n\r\n<p>[site:login-url]</p>\r\n\r\n<p>Best regards,</p>\r\n\r\n<p>Palvelumanuaali administration</p>\r\n"
+    value: "<p>Hei [user:display-name]</p>\r\n\r\n<p>Käyttäjätilisi sivustolla [site:name] on ollut epäaktiivinen yli 5 kuukautta. Tilisi vanhenee ja poistetaan, jos et käytä palvelua.</p>\r\n\r\n<p>Jos haluat jatkaa palvelun käyttöä, käy aktivoimassa tilisi. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href=\"[site:login-url]\">[site:login-url]</a></p>\r\n\r\n<p>Jos et enää käytä palvelua, voit jättää tämän viestin huomioimatta ja tilisi vanhenee automaattisesti 48 tunnin kuluttua.</p>\r\n\r\n<p>Ystävällisin terveisin<br />\r\n[site:name]-tiimi</p>\r\n\r\n<p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>\r\n"
     format: filtered_html
 settings:
   'token options':

--- a/config/sync/message.template.hel_tpm_user_expiry_blocked.yml
+++ b/config/sync/message.template.hel_tpm_user_expiry_blocked.yml
@@ -1,0 +1,23 @@
+uuid: c03b7315-1b0d-4b56-b6ad-ff21f099fe9a
+langcode: fi
+status: true
+dependencies:
+  config:
+    - filter.format.email_html
+    - filter.format.plain_text_format
+template: hel_tpm_user_expiry_blocked
+label: hel_tpm_user_expiry_blocked
+description: 'Account deactivated after inactivity'
+text:
+  -
+    value: 'Henkilön [user:display-name] käyttäjätili on lukittu sivustolla [site:name]'
+    format: plain_text_format
+  -
+    value: '<p>Hei [user:display-name]</p><p>Käyttäjätilisi on suljettu sivustolla [site:name]. Jos tilin sulkeminen on ollut virheellinen, ole yhteydessä oman organisaatiosi pääkäyttäjään. Ylläpito voi uudelleen aktivoida suljetun tilin 30 päivän sisällä sen sulkemisesta.</p><p>Tämä viesti on lähetetty automaattisesti.</p><p>Ystävällisin terveisin<br>[site:name]-tiimi</p><p>Epäaktiivisten käyttäjien tietojen käsittely järjestelmässä on perusteetonta. Henkilötietosi poistetaan palvelusta pysyvästi 30 päivää tilin sulkemisen jälkeen. Tänä aikana järjestelmän ylläpitäjä voi vielä palauttaa tilin.</p>'
+    format: email_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -26,7 +26,7 @@ function _hel_tpm_user_expiry_notification_cron() {
     return;
   }
 
-  $limit = strtotime('-3 months -2 weeks');
+  $limit = strtotime('-165 days');
 
   // Fetch all users have been inactive for 3 months and 2 weeks.
   $q = Drupal::database()->select('users_field_data', 'ufd')

--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -33,8 +33,13 @@ function _hel_tpm_user_expiry_notification_cron() {
     ->fields('ufd', ['uid', 'access', 'status'])
     ->condition('uid', 0, '<>')
     ->condition('access', $limit, '<=')
-    ->condition('created', $limit, '<=')
-    ->condition('status', 1);
+    ->condition('created', $limit, '<=');
+
+  // Exclude users that has been anonymized.
+  if ($anonymized_users = \Drupal::state()->get('hel_tpm_user_expiry.anonymized_users')) {
+    $q->condition('uid', $anonymized_users, 'NOT IN');
+  }
+
   $result = $q->execute()->fetchAll();
 
   foreach ($result as $user) {

--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -28,7 +28,7 @@ function _hel_tpm_user_expiry_notification_cron() {
 
   $limit = strtotime('-165 days');
 
-  // Fetch all users have been inactive for 3 months and 2 weeks.
+  // Fetch all users have been inactive for 5 months and 2 weeks.
   $q = Drupal::database()->select('users_field_data', 'ufd')
     ->fields('ufd', ['uid', 'access', 'status'])
     ->condition('uid', 0, '<>')

--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -32,6 +32,7 @@ function _hel_tpm_user_expiry_notification_cron() {
   $q = Drupal::database()->select('users_field_data', 'ufd')
     ->fields('ufd', ['uid', 'access', 'status'])
     ->condition('uid', 0, '<>')
+    ->condition('uid', 1, '<>')
     ->condition('access', $limit, '<=')
     ->condition('created', $limit, '<=');
 

--- a/public/modules/custom/hel_tpm_user_expiry/src/Plugin/QueueWorker/UserExpirationNotification.php
+++ b/public/modules/custom/hel_tpm_user_expiry/src/Plugin/QueueWorker/UserExpirationNotification.php
@@ -104,7 +104,7 @@ final class UserExpirationNotification extends QueueWorkerBase implements Contai
     }
 
     if ($this->getTimeLimit($count) >= $timestamp) {
-      // Deactivate user if last notification has been sent 5 days ago.
+      // Deactivate user if last notification has been sent 2 days ago.
       $this->deactivateUser();
       // Delete state after we have queued user for deactivation.
       // Prevents continous deactivation if account is activated by hand
@@ -220,7 +220,7 @@ final class UserExpirationNotification extends QueueWorkerBase implements Contai
   }
 
   /**
-   * Notification sending methdo.
+   * Notification sending method.
    *
    * @param int $uid
    *   User id who message is sent.
@@ -231,6 +231,7 @@ final class UserExpirationNotification extends QueueWorkerBase implements Contai
    *   -
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\message_notify\Exception\MessageNotifyException
    */
   protected function sendNotification(int $uid, string $template): void {
     $message = Message::create([

--- a/public/modules/custom/hel_tpm_user_expiry/src/Plugin/QueueWorker/UserExpirationNotification.php
+++ b/public/modules/custom/hel_tpm_user_expiry/src/Plugin/QueueWorker/UserExpirationNotification.php
@@ -256,7 +256,7 @@ final class UserExpirationNotification extends QueueWorkerBase implements Contai
     $user = User::load($this->getUid());
     // Perform extra checks before anonymizing user data.
     if (!$user->isBlocked()
-      || $user->get('access') > strtotime('-210 days')
+      || $user->get('access')->value >= strtotime('-210 days')
       || ($user->id() == 0 || $user->id() == 1)) {
       return FALSE;
     }

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.field.user.user.field_employer.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.field.user.user.field_employer.yml
@@ -1,0 +1,19 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_employer
+  module:
+    - user
+id: user.user.field_employer
+field_name: field_employer
+entity_type: user
+bundle: user
+label: Employer
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.field.user.user.field_job_title.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.field.user.user.field_job_title.yml
@@ -1,0 +1,19 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_job_title
+  module:
+    - user
+id: user.user.field_job_title
+field_name: field_job_title
+entity_type: user
+bundle: user
+label: 'Job  title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.field.user.user.field_name.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.field.user.user.field_name.yml
@@ -1,0 +1,19 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_name
+  module:
+    - user
+id: user.user.field_name
+field_name: field_name
+entity_type: user
+bundle: user
+label: Name
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.storage.user.field_employer.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.storage.user.field_employer.yml
@@ -1,0 +1,20 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_employer
+field_name: field_employer
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.storage.user.field_job_title.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.storage.user.field_job_title.yml
@@ -1,0 +1,20 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_job_title
+field_name: field_job_title
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.storage.user.field_name.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/field.storage.user.field_name.yml
@@ -1,0 +1,20 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_name
+field_name: field_name
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/message.template.hel_tpm_user_expiry_blocked.yml
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/modules/hel_tpm_user_expiry_messages_test/config/install/message.template.hel_tpm_user_expiry_blocked.yml
@@ -1,0 +1,22 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - filter.format.email_html
+    - filter.format.plain_text_format
+template: hel_tpm_user_expiry_blocked
+label: hel_tpm_user_expiry_blocked
+description: 'Account deactivated after inactivity'
+text:
+  -
+    value: 'Account [user:display-name] is closed at the [site:name] site'
+    format: plain_text_format
+  -
+    value: '<p>Hello [user:display-name]</p><p>Your account is deactivated at the [site:name] site.</p>'
+    format: email_html
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
@@ -5,9 +5,12 @@ declare(strict_types = 1);
 namespace Drupal\Tests\hel_tpm_user_expiry\Kernel;
 
 use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Test\AssertMailTrait;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Test description.
@@ -120,60 +123,182 @@ final class UserExpirationTest extends EntityKernelTestBase {
 
   /**
    * Test user expiration notifications.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function testUserExpirationNotifications() {
-    $last_access = strtotime('-165 days');
-    $user = $this->createUser();
-    $this->connection->update('users_field_data')
-      ->condition('uid', $user->id())
-      ->fields([
-        'access' => $last_access,
-        'created' => $last_access,
-      ])
-      ->execute();
+    $user = $this->createLastAccessUser(2);
+
     $this->cron->run();
+    // Ensure the first notification is sent.
     $this->assertNotEmpty($this->drupalGetMails([
       'id' => 'message_notify_1st_user_account_expiry_reminder',
     ]));
 
-    $this->resetCronLastRun();
-    $this->updateStateTimestamp('-1 weeks', $user);
-    $this->cron->run();
-
-    // Validate that 2nd message is not sent before
-    // 2 weeks since last notification.
+    $this->cronRunHelper('-1 weeks', [$user]);
+    // Ensure the second notification is not sent before time limit.
     $this->assertEmpty($this->drupalGetMails([
       'id' => 'message_notify_2nd_user_account_expiry_reminder',
     ]));
 
-    $this->resetCronLastRun();
-    $this->updateStateTimestamp('-2 weeks', $user);
-
-    $this->cron->run();
+    $this->cronRunHelper('-2 weeks', [$user]);
+    // Ensure the second notification is sent after time limit.
     $this->assertNotEmpty($this->drupalGetMails([
       'id' => 'message_notify_2nd_user_account_expiry_reminder',
     ]));
 
-    $this->resetCronLastRun();
-    $this->cron->run();
+    $this->cronRunHelper('-1 days', [$user]);
+    // Ensure the deactivation message is not sent before time limit.
+    $this->assertEmpty($this->drupalGetMails([
+      'id' => 'message_notify_hel_tpm_user_expiry_blocked',
+    ]));
 
-    $this->resetCronLastRun();
-    $this->updateStateTimestamp('-1 days', $user);
+    $this->cronRunHelper('-2 days', [$user]);
+    // Ensure the deactivation message is sent after time limit.
+    $this->assertNotEmpty($this->drupalGetMails([
+      'id' => 'message_notify_hel_tpm_user_expiry_blocked',
+    ]));
+
+    $this->cronRunHelper('-1 days', [$user]);
+    $this->cronRunHelper('-2 days', [$user]);
+    $this->cronRunHelper('-2 weeks', [$user]);
+    $this->cronRunHelper('-30 days', [$user]);
+    // Ensure no further mails are sent.
+    $this->assertCount(3, $this->drupalGetMails());
+  }
+
+  /**
+   * Test user expiration deactivation.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testUserExpirationDeactivation() {
+    $user = $this->createLastAccessUser(2);
+
     $this->cron->run();
     $user = $this->reloadEntity($user);
+    // Ensure user is active after the first cron run.
     $this->assertEquals('1', $user->get('status')->value);
 
-    $this->resetCronLastRun();
-    $this->updateStateTimestamp('-2 days', $user);
-    $this->cron->run();
+    $this->cronRunHelper('-2 weeks', [$user]);
     $user = $this->reloadEntity($user);
-    $this->assertEquals(0, $user->get('status')->value);
+    // Ensure user is still active after two more weeks.
+    $this->assertEquals('1', $user->get('status')->value);
 
-    $this->resetCronLastRun();
+    $this->cronRunHelper('-2 days', [$user]);
+    $user = $this->reloadEntity($user);
+    // Ensure user is blocked after two more days.
+    $this->assertEquals('0', $user->get('status')->value);
+  }
+
+  /**
+   * Test user expiration anonymization.
+   *
+   * @return void
+   *   Void.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testUserExpirationAnonymization(): void {
+    $users = [
+      'inactive' => $this->createLastAccessUser(2, '-250 days'),
+      'active' => $this->createLastAccessUser(3, '-165 days'),
+    ];
+
     $this->cron->run();
-    // Confirm no mails are sent to user after user is disabled.
-    $this->assertCount(2, $this->drupalGetMails());
+    $this->cronRunHelper('-2 weeks', $users);
+    $this->cronRunHelper('-2 days', $users);
 
+    $inactiveOldValues = $this->getFieldsForAnonymizationTest($users['inactive']);
+    $activeOldValues = $this->getFieldsForAnonymizationTest($users['active']);
+
+    $this->cronRunHelper('-30 days', $users);
+    $users['inactive'] = $this->reloadEntity($users['inactive']);
+    $users['active'] = $this->reloadEntity($users['active']);
+
+    // Ensure values are anonymized for user with enough inactivation time.
+    foreach ($inactiveOldValues as $key => $oldValue) {
+      $this->assertNotEquals($oldValue, $users['inactive']->get($key)->value);
+    }
+
+    // Ensure values are not anonymized for user without enough inactivation
+    // time.
+    foreach ($activeOldValues as $key => $oldValue) {
+      $this->assertEquals($oldValue, $users['active']->get($key)->value);
+    }
+  }
+
+  /**
+   * Creates a user with given inactivity period.
+   *
+   * @param int $uid
+   *   The user id.
+   * @param string $lastAccess
+   *   The strtotime format of user's last access.
+   *
+   * @return \Drupal\user\UserInterface
+   *   The user entity.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createLastAccessUser(int $uid = 1, string $lastAccess = '-165 days'): UserInterface {
+    $access = strtotime($lastAccess);
+    $user = $this->createUser([], NULL, FALSE, [
+      'uid' => $uid,
+      'mail' => 'test-' . $uid . 'tpm.test',
+      'field_name' => 'Test name ' . $uid,
+      'field_job_title' => 'Test job title ' . $uid,
+      'field_employer' => 'Test employer ' . $uid,
+      'created' => $access,
+      'access' => $access,
+    ]);
+    $this->connection->update('users_field_data')
+      ->condition('uid', $user->id())
+      ->fields([
+        'access' => $access,
+        'created' => $access,
+      ])
+      ->execute();
+    return $user;
+  }
+
+  /**
+   * Helper function to get user fields for anonymization test.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   The user.
+   *
+   * @return array
+   *   Use field values.
+   */
+  protected function getFieldsForAnonymizationTest(UserInterface $user): array {
+    // The name field is not tested as it's generated using another module.
+    return [
+      'mail' => $user->get('mail')->value,
+      'pass' => $user->get('pass')->value,
+      'field_name' => $user->get('field_name')->value,
+      'field_job_title' => $user->get('field_job_title')->value,
+      'field_employer' => $user->get('field_employer')->value,
+    ];
+  }
+
+  /**
+   * Helper function to run cron and related actions.
+   *
+   * @param string $date
+   *   Date in strtotime format.
+   * @param array $users
+   *   An array of users.
+   *
+   * @return void
+   *   Void.
+   */
+  protected function cronRunHelper(string $date, array $users): void {
+    $this->resetCronLastRun();
+    foreach ($users as $user) {
+      $this->updateStateTimestamp($date, $user);
+    }
+    $this->cron->run();
   }
 
   /**
@@ -188,13 +313,13 @@ final class UserExpirationTest extends EntityKernelTestBase {
    *
    * @param string $date
    *   Date in strtotime format.
-   * @param \Drupal\user\UserInterface $user
+   * @param \Drupal\Core\Entity\EntityInterface $user
    *   User object.
    *
    * @return void
    *   Void
    */
-  protected function updateStateTimestamp($date, $user) {
+  protected function updateStateTimestamp(string $date, EntityInterface $user): void {
     $state = \Drupal::state()->get('hel_tpm_user_expiry.notified.' . $user->id());
     $state['timestamp'] = strtotime($date);
     \Drupal::state()->set('hel_tpm_user_expiry.notified.' . $user->id(), $state);

--- a/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
@@ -203,6 +203,7 @@ final class UserExpirationTest extends EntityKernelTestBase {
     $users = [
       'inactive' => $this->createLastAccessUser(2, '-250 days'),
       'active' => $this->createLastAccessUser(3, '-165 days'),
+      'user_id_1' => $this->createLastAccessUser(1, '-250 days'),
     ];
 
     $this->cron->run();
@@ -211,10 +212,12 @@ final class UserExpirationTest extends EntityKernelTestBase {
 
     $inactiveOldValues = $this->getFieldsForAnonymizationTest($users['inactive']);
     $activeOldValues = $this->getFieldsForAnonymizationTest($users['active']);
+    $uid1OldValues = $this->getFieldsForAnonymizationTest($users['user_id_1']);
 
     $this->cronRunHelper('-30 days', $users);
     $users['inactive'] = $this->reloadEntity($users['inactive']);
     $users['active'] = $this->reloadEntity($users['active']);
+    $users['user_id_1'] = $this->reloadEntity($users['user_id_1']);
 
     // Ensure values are anonymized for user with enough inactivation time.
     foreach ($inactiveOldValues as $key => $oldValue) {
@@ -225,6 +228,11 @@ final class UserExpirationTest extends EntityKernelTestBase {
     // time.
     foreach ($activeOldValues as $key => $oldValue) {
       $this->assertEquals($oldValue, $users['active']->get($key)->value);
+    }
+
+    // Ensure values are not anonymized for user ID 1.
+    foreach ($inactiveOldValues as $key => $oldValue) {
+      $this->assertEquals($oldValue, $users['inactive']->get($key)->value);
     }
   }
 

--- a/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
@@ -98,7 +98,7 @@ final class UserExpirationTest extends EntityKernelTestBase {
    * Test user expiration cron queueing.
    */
   public function testUserExpirationQueueingCron() {
-    $last_access = strtotime('-3 months -2 weeks');
+    $last_access = strtotime('-165 days');
     $user = $this->createUser();
     $this->cron->run();
     $this->assertEquals(0, $this->queue->numberOfItems());
@@ -122,7 +122,7 @@ final class UserExpirationTest extends EntityKernelTestBase {
    * Test user expiration notifications.
    */
   public function testUserExpirationNotifications() {
-    $last_access = strtotime('-3 months -2 weeks');
+    $last_access = strtotime('-165 days');
     $user = $this->createUser();
     $this->connection->update('users_field_data')
       ->condition('uid', $user->id())


### PR DESCRIPTION
**Description:**

* Updates reminder messages.
* Adds new message for account deactivation.
* Anonymizes accounts 30 days after deactivation.

**Actions necessary for applying the changes:**

`lando drush deploy`

**Testing instructions:**

For manual testing, you need to alter timestamps in database:
- [x] Calculate a timestamp that was at least 165 days ago.
- [x] Calculate a timestamp that was at least 210 days ago.
- [x] Calculate a timestamp that was at least 2 weeks ago.
- [x] Calculate a timestamp that was at least 2 days ago.
- [x] Calculate a timestamp that was at least 30 days ago.

Preparations for local testing environment:
- [x] Edit some existing active user's `created` and `acceess` fields to timestamp at least 165 days ago.
- [x] Edit another existing active user's `created` and `acceess` fields to timestamp at least 210 days ago.
- [x] For both users, edit the user form to have information in the name, job title, etc. fields.
- [x] Change the passwords.
- [x] From the `key_value` table delete any existing `hel_tpm_user_expiry.last_run` row.
- [x] Also check from the same table there is no existing notified info for the test users by deleting `hel_tpm_user_expiry.notified.<UID>` rows.

Running cron:
- [x] Run the cron: `lando drush cron`
- [x] Use mailhog to check that there are the updated first user expiry notification messages for the test users.
- [x] Re-running the cron should not send new messages.
- [x] Edit the users' `hel_tpm_user_expiry.notified.<UID>` rows timestamps to have the "2 weeks ago" timestamps.
- [x] Run the cron.
- [x] Check that the updated second user expiry notification messages are sent for the test users.
- [x] Edit the users' `hel_tpm_user_expiry.notified.<UID>` rows timestamps to have the "2 days ago" timestamps.
- [x] Run the cron.
- [x] The users should now be blocked.
- [x] Check that accound deactivated messages are sent the test users.
- [x] Edit the users' `hel_tpm_user_expiry.notified.<UID>` rows timestamps to have the "30 days ago" timestamps.
- [x] Run the cron.
- [x] Check that the user who's access field was set to "210 days ago" is now anonymized. The user edit form should only show empty fields and the username and email are anonymized.
- [x] Check that the other user is not .
- [x] For testing purposes, activate the anonymized account and make sure you can't login with the old password.

Run automated tests:
- [x] Check that tests pass: `lando test public/modules/custom/hel_tpm_user_expiry/tests/`

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
