### PR TITLE
TP-1331 Delete user expiry state when unblocking user

### DIFF
--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -5,6 +5,8 @@
  * Module file for hel_tpm_user_expiry.
  */
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 
 /**
@@ -54,12 +56,37 @@ function _hel_tpm_user_expiry_notification_cron() {
 /**
  * Implements hook_user_login().
  */
-function hel_tpm_user_expiry_user_login(UserInterface $account) {
-  $state_manager = Drupal::state();
-  $state_name = 'hel_tpm_user_expiry.notified.' . $account->id();
-  $state = $state_manager->get($state_name);
+function hel_tpm_user_expiry_user_login(UserInterface $account): void {
   // Clear user expiry notification state after user has logged in.
-  if (!empty($state)) {
+  _hel_tpm_user_expiry_delete_notified_state($account->id());
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function hel_tpm_user_expiry_user_update(EntityInterface $entity): void {
+  if (!$entity instanceof User) {
+    return;
+  }
+  if ($entity->original->isBlocked() && $entity->isActive()) {
+    // Clear user expiry notification state when blocked user is set to active.
+    _hel_tpm_user_expiry_delete_notified_state($entity->id());
+  }
+}
+
+/**
+ * Helper function to clear user expiry notification state.
+ *
+ * @param int $uid
+ *   The user id.
+ *
+ * @return void
+ *   -
+ */
+function _hel_tpm_user_expiry_delete_notified_state(int $uid): void {
+  $state_manager = Drupal::state();
+  $state_name = 'hel_tpm_user_expiry.notified.' . $uid;
+  if (!empty($state_manager->get($state_name))) {
     $state_manager->delete($state_name);
   }
 }


### PR DESCRIPTION
**Actions necessary for applying the changes:**

drush deploy

**Testing instructions:**
- [x] Follow instructions from https://github.com/City-of-Helsinki/drupal-helfi-tyollisyyspalvelut-manuaali/pull/662 so that you can reproduce blocking a test user.
- [x] Check from the database `key_value` table that there is a corresponding `hel_tpm_user_expiry.notified.<UID>` row.
- [x] Login as admin and unblock the user.
- [x] Check that the database row is now missing.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
