### PR TITLE
TP-1334 Fix twig template rendering language field in taxonomy views

### DIFF
--- a/public/themes/custom/palvelumanuaali/templates/fields/field--field-service-languages--paragraph--limited-fields.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/fields/field--field-service-languages--paragraph--limited-fields.html.twig
@@ -51,5 +51,6 @@
   field_header: 'Service language'|t,
   additional_classes: additional_classes,
   icon_name: 'speech-bubble-dark-blue',
+  language_field: TRUE,
 }
 %}

--- a/public/themes/custom/palvelumanuaali/templates/fields/field--field-service-languages--paragraph--taxonomy-card.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/fields/field--field-service-languages--paragraph--taxonomy-card.html.twig
@@ -13,5 +13,6 @@
     additional_classes: additional_classes,
     icon_name: 'speech-bubble-dark-blue',
     limit: 'yes',
+    language_field: TRUE,
   }
 %}


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

`Drush cr`

**Testing instructions:**
- [x] Go to some taxonomy view page (/palvelut-helsinkilaisille) and confirm that service languages with level render properly

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
