### PR TITLE
TP-1070 Add tests for hel_tpm_update_reminder module

### DIFF
--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.module
@@ -25,9 +25,6 @@ function hel_tpm_update_reminder_cron() {
  *
  * @return void
  *   Void.
- *
- * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
- * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
  */
 function _hel_tpm_update_reminder_service_reminders(): void {
   if (!UpdateReminderUtility::shouldRun()) {
@@ -45,11 +42,13 @@ function _hel_tpm_update_reminder_service_reminders(): void {
   // services' changed status.
   $reminder_service_ids = \Drupal::entityQuery('node')
     ->condition('type', 'service')
-    ->condition('nid', $published_moderation_nids, 'IN')
     ->condition('status', NodeInterface::PUBLISHED)
     ->condition('changed', UpdateReminderUtility::getFirstServiceLimit(), '<')
-    ->accessCheck(FALSE)
-    ->execute();
+    ->accessCheck(FALSE);
+  if (!empty($published_moderation_nids)) {
+    $reminder_service_ids->condition('nid', $published_moderation_nids, 'IN');
+  }
+  $reminder_service_ids = $reminder_service_ids->execute();
 
   $queue = Drupal::queue('hel_tpm_update_reminder_service');
   foreach ($reminder_service_ids as $nid) {

--- a/public/modules/custom/hel_tpm_update_reminder/src/UpdateReminderUtility.php
+++ b/public/modules/custom/hel_tpm_update_reminder/src/UpdateReminderUtility.php
@@ -32,17 +32,17 @@ class UpdateReminderUtility {
   /**
    * State API key for update reminder last run timestamp.
    */
-  private const LAST_RUN_KEY = 'hel_tpm_update_reminder.last_run';
+  public const LAST_RUN_KEY = 'hel_tpm_update_reminder.last_run';
 
   /**
    * Base State API key for node's last checked timestamp.
    */
-  private const CHECKED_TIMESTAMP_BASE_KEY = 'hel_tpm_update_reminder.checked_timestamp.node.';
+  public const CHECKED_TIMESTAMP_BASE_KEY = 'hel_tpm_update_reminder.checked_timestamp.node.';
 
   /**
    * Base State API key for node's messages sent counter.
    */
-  private const MESSAGES_SENT_BASE_KEY = 'hel_tpm_update_reminder.messages_sent.node.';
+  public const MESSAGES_SENT_BASE_KEY = 'hel_tpm_update_reminder.messages_sent.node.';
 
   /**
    * Get the last run timestamp.

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.content_has_been_published.field_message_author.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.content_has_been_published.field_message_author.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_message_author
+    - message.template.content_has_been_published
+third_party_settings: { }
+id: message.content_has_been_published.field_message_author
+field_name: field_message_author
+entity_type: message
+bundle: content_has_been_published
+label: 'Message author'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.content_has_been_published.field_node.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.content_has_been_published.field_node.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_node
+    - message.template.content_has_been_published
+    - node.type.service
+third_party_settings: { }
+id: message.content_has_been_published.field_node
+field_name: field_node
+entity_type: message
+bundle: content_has_been_published
+label: Node
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.content_has_been_published.field_user.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.content_has_been_published.field_user.yml
@@ -1,0 +1,31 @@
+uuid: b90cfa2d-7cc4-4ae6-9ec8-5f7eb2a660b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_user
+    - message.template.content_has_been_published
+third_party_settings: { }
+id: message.content_has_been_published.field_user
+field_name: field_user
+entity_type: message
+bundle: content_has_been_published
+label: User
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+    filter:
+      type: _none
+    include_anonymous: false
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_outdated.field_node.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_outdated.field_node.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_node
+    - message.template.hel_tpm_update_reminder_outdated
+    - node.type.service
+id: message.hel_tpm_update_reminder_outdated.field_node
+field_name: field_node
+entity_type: message
+bundle: hel_tpm_update_reminder_outdated
+label: Node
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      service: service
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_outdated.field_user.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_outdated.field_user.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_user
+    - message.template.hel_tpm_update_reminder_outdated
+id: message.hel_tpm_update_reminder_outdated.field_user
+field_name: field_user
+entity_type: message
+bundle: hel_tpm_update_reminder_outdated
+label: User
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+    filter:
+      type: _none
+    include_anonymous: false
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_service.field_node.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_service.field_node.yml
@@ -1,0 +1,29 @@
+uuid: 714e093a-c2b3-4b35-bcc1-33ae63b84dec
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_node
+    - message.template.hel_tpm_update_reminder_service
+    - node.type.service
+id: message.hel_tpm_update_reminder_service.field_node
+field_name: field_node
+entity_type: message
+bundle: hel_tpm_update_reminder_service
+label: Node
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      service: service
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_service.field_user.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.message.hel_tpm_update_reminder_service.field_user.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.message.field_user
+    - message.template.hel_tpm_update_reminder_service
+id: message.hel_tpm_update_reminder_service.field_user
+field_name: field_user
+entity_type: message
+bundle: hel_tpm_update_reminder_service
+label: User
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+    filter:
+      type: _none
+    include_anonymous: false
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.node.service.field_responsible_updatee.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.node.service.field_responsible_updatee.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_responsible_updatee
+    - node.type.service
+id: node.service.field_responsible_updatee
+field_name: field_responsible_updatee
+entity_type: node
+bundle: service
+label: 'Responsible for service in municipality'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.node.service.field_service_provider_updatee.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.field.node.service.field_service_provider_updatee.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_service_provider_updatee
+    - node.type.service
+id: node.service.field_service_provider_updatee
+field_name: field_service_provider_updatee
+entity_type: node
+bundle: service
+label: 'Responsible for service in the organisation'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: entity_reference

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.message.field_message_author.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.message.field_message_author.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+    - user
+id: message.field_message_author
+field_name: field_message_author
+entity_type: message
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.message.field_node.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.message.field_node.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+    - node
+id: message.field_node
+field_name: field_node
+entity_type: message
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.message.field_user.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.message.field_user.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - message
+    - user
+id: message.field_user
+field_name: field_user
+entity_type: message
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.node.field_responsible_updatee.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.node.field_responsible_updatee.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: node.field_responsible_updatee
+field_name: field_responsible_updatee
+entity_type: node
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.node.field_service_provider_updatee.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/field.storage.node.field_service_provider_updatee.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: node.field_service_provider_updatee
+field_name: field_service_provider_updatee
+entity_type: node
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/message.template.content_has_been_published.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/message.template.content_has_been_published.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+template: content_has_been_published
+label: 'Service has been published'
+description: ''
+text:
+  -
+    value: "Service [message:field_node:entity:title] has been published"
+    format: filtered_html
+settings: {  }

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/message.template.hel_tpm_update_reminder_outdated.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/message.template.hel_tpm_update_reminder_outdated.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.plain_text_format
+template: hel_tpm_update_reminder_outdated
+label: hel_tpm_update_reminder_outdated
+description: 'Service outdated message'
+text:
+  -
+    value: 'Service [message:field_node:entity:title] is outdated'
+    format: plain_text_format
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/message.template.hel_tpm_update_reminder_service.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/message.template.hel_tpm_update_reminder_service.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.plain_text_format
+template: hel_tpm_update_reminder_service
+label: hel_tpm_update_reminder_service
+description: 'Service update reminder'
+text:
+  -
+    value: "Validate service [message:field_node:entity:title]\r\n"
+    format: plain_text_format
+settings:
+  'token options':
+    clear: false
+    'token replace': true
+  purge_override: false
+  purge_methods: {  }

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/node.type.service.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/node.type.service.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: { }
+third_party_settings: { }
+name: Service
+type: service
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/workflows.workflow.service_moderation.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/workflows.workflow.service_moderation.yml
@@ -1,0 +1,95 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.service
+  module:
+    - content_moderation
+id: service_moderation
+label: 'Service moderation'
+type: content_moderation
+type_settings:
+  states:
+    archived:
+      label: Archived
+      weight: 2
+      published: false
+      default_revision: true
+    draft:
+      label: Draft
+      weight: -4
+      published: false
+      default_revision: false
+    outdated:
+      label: Outdated
+      weight: 0
+      published: false
+      default_revision: true
+    published:
+      label: Published
+      weight: -2
+      published: true
+      default_revision: true
+    ready_to_publish:
+      label: 'Ready to publish'
+      weight: -3
+      published: false
+      default_revision: false
+  transitions:
+    archived:
+      label: Archived
+      from:
+        - archived
+        - outdated
+        - published
+      to: archived
+      weight: 3
+    create_new_draft:
+      label: 'Create New Draft'
+      from:
+        - archived
+        - draft
+        - published
+      to: draft
+      weight: -4
+    outdated:
+      label: Outdated
+      from:
+        - draft
+        - outdated
+        - published
+      to: outdated
+      weight: 1
+    outdated_to_draft:
+      label: 'Outdated to draft'
+      from:
+        - outdated
+      to: draft
+      weight: 4
+    publish:
+      label: Publish
+      from:
+        - draft
+        - published
+        - ready_to_publish
+      to: published
+      weight: -1
+    ready_to_publish:
+      label: 'Ready to publish'
+      from:
+        - draft
+        - outdated
+        - published
+        - ready_to_publish
+      to: ready_to_publish
+      weight: -3
+    ready_to_publish_to_draft:
+      label: 'Ready to publish to draft'
+      from:
+        - ready_to_publish
+      to: draft
+      weight: -2
+  entity_types:
+    node:
+      - service
+  default_moderation_state: draft

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/hel_tpm_update_reminder_test.info.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/hel_tpm_update_reminder_test.info.yml
@@ -1,0 +1,13 @@
+name: 'Update reminder test configs'
+type: module
+description: 'Provides example configurations for update reminder tests'
+package: Testing
+core_version_requirement: ^9 || ^10
+dependencies:
+  - drupal:content_moderation
+  - drupal:node
+  - drupal:entity_test
+  - drupal:message
+  - drupal:message_notify
+  - drupal:message_notify_test
+  - service_manual_workflow:service_manual_workflow

--- a/public/modules/custom/hel_tpm_update_reminder/tests/src/Kernel/ServiceUpdateReminderTest.php
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/src/Kernel/ServiceUpdateReminderTest.php
@@ -1,0 +1,397 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\hel_tpm_update_reminder\Kernel;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Test\AssertMailTrait;
+use Drupal\hel_tpm_update_reminder\UpdateReminderUtility;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Service update reminder tests.
+ *
+ * @group hel_tpm_update_reminder
+ */
+final class ServiceUpdateReminderTest extends EntityKernelTestBase {
+
+  use UserCreationTrait;
+  use AssertMailTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'content_moderation',
+    'workflows',
+    'node',
+    'flexible_permissions',
+    'gcontent_moderation',
+    'message',
+    'message_notify',
+    'message_notify_test',
+    'service_manual_workflow',
+    'group',
+    'ggroup',
+    'hel_tpm_update_reminder',
+    'hel_tpm_update_reminder_test',
+  ];
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The cron service.
+   *
+   * @var \Drupal\Core\Cron
+   */
+  protected $cron;
+
+  /**
+   * The queue container.
+   *
+   * @var \Drupal\Core\Queue\DatabaseQueue
+   */
+  protected $queue;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('content_moderation_state');
+    $this->installEntitySchema('message');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['field', 'node', 'system']);
+    $this->installConfig([
+      'content_moderation',
+      'hel_tpm_update_reminder_test',
+    ]);
+
+    $this->cron = \Drupal::service('cron');
+    $this->connection = Database::getConnection();
+    $this->queue = $this->container->get('queue')->get('hel_tpm_update_reminder_service');
+  }
+
+  /**
+   * Tests running cron.
+   *
+   * @return void
+   *     -
+   */
+  public function testCronRuns(): void {
+    // Ensure cron runs.
+    $this->cron->run();
+    $this->assertEquals(\Drupal::time()->getRequestTime(), UpdateReminderUtility::getLastRun());
+
+    // Ensure cron runs after last run has passed the time limit.
+    $this->updateLastRunTimestamp();
+    $limitPassedTimestamp = UpdateReminderUtility::getLastRun();
+    $this->cron->run();
+    $this->assertNotEquals($limitPassedTimestamp, UpdateReminderUtility::getLastRun());
+
+    // Ensure cron does not run before last run has passed the time limit.
+    $this->updateLastRunTimestamp(UpdateReminderUtility::RUN_LIMIT_HOURS - 1);
+    $limitNotPassedTimestamp = UpdateReminderUtility::getLastRun();
+    $this->cron->run();
+    $this->assertEquals($limitNotPassedTimestamp, UpdateReminderUtility::getLastRun());
+  }
+
+  /**
+   * Tests cron queueing with services having published moderation state.
+   *
+   * The moderation state transitions should allow cron to add the service ids
+   * to the queue.
+   *
+   * @return void
+   *     -
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testQueueWithTransitions(): void {
+    $daysAgo = UpdateReminderUtility::SERVICE_LIMIT_1 + 1;
+    $services = [
+      $this->createServiceWithTransition('draft', 'published', $daysAgo),
+      $this->createServiceWithTransition('ready_to_publish', 'published', $daysAgo),
+      $this->createServiceWithTransition('published', 'published', $daysAgo),
+      $this->createServiceWithTransition('published', 'ready_to_publish', $daysAgo),
+    ];
+    // Only run specific cron function for keeping the items in queue.
+    _hel_tpm_update_reminder_service_reminders();
+    $this->assertEquals(4, $this->queue->numberOfItems());
+  }
+
+  /**
+   * Tests cron queueing with recently checked services.
+   *
+   * The services that are checked before the first time limit is passed should
+   * not have their ids added to the queue.
+   *
+   * @return void
+   *    -
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testQueueWithRecentlyChecked(): void {
+    $daysAgo = UpdateReminderUtility::SERVICE_LIMIT_1 - 1;
+    $servicesRecent = [
+      $this->createServiceWithTransition('draft', 'published', $daysAgo),
+      $this->createServiceWithTransition('ready_to_publish', 'published', $daysAgo),
+      $this->createServiceWithTransition('published', 'published', $daysAgo),
+      $this->createServiceWithTransition('published', 'ready_to_publish', $daysAgo),
+    ];
+    // Only run specific cron function for keeping the items in queue.
+    _hel_tpm_update_reminder_service_reminders();
+    $this->assertEquals(0, $this->queue->numberOfItems());
+  }
+
+  /**
+   * Tests cron queueing with services not having published moderation state.
+   *
+   * The moderation state transitions should not allow cron to add the service
+   * ids to the queue.
+   *
+   * @return void
+   *    -
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testQueueWithTransitionsNotPublished(): void {
+    $daysAgo = UpdateReminderUtility::SERVICE_LIMIT_1 + 1;
+    $notPublishedServices = [
+      $this->createServiceWithTransition('draft', 'ready_to_publish', $daysAgo),
+      $this->createServiceWithTransition('ready_to_publish', 'ready_to_publish', $daysAgo),
+    ];
+    // Only run specific cron function for keeping the items in queue.
+    _hel_tpm_update_reminder_service_reminders();
+    $this->assertEquals(0, $this->queue->numberOfItems());
+  }
+
+  /**
+   * Tests sending reminder messages and finally marking service as outdated.
+   *
+   * @return void
+   *   -
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testRemindersAndOutdated(): void {
+    // Ensure the first reminder is sent.
+    $checkedDaysAgo = UpdateReminderUtility::SERVICE_LIMIT_1 + 1;
+    $service = $this->createServiceWithTransition('ready_to_publish', 'published', $checkedDaysAgo, TRUE);
+    $this->cron->run();
+    $this->assertEquals(1, count($this->getReminderMails()));
+
+    // Ensure the second reminder is sent.
+    $checkedDaysAgo = UpdateReminderUtility::SERVICE_LIMIT_2 + 1;
+    $this->setCheckedTimestamp((int) $service->id(), $checkedDaysAgo);
+    $this->cronRunHelper();
+    $this->assertEquals(2, count($this->getReminderMails()));
+
+    // Ensure the service is outdated and the related message is sent.
+    $checkedDaysAgo = UpdateReminderUtility::SERVICE_LIMIT_3 + 1;
+    $this->setCheckedTimestamp((int) $service->id(), $checkedDaysAgo);
+    $this->cronRunHelper();
+    $this->assertEquals(1, count($this->getOutdatedMails()));
+    $service = $this->reloadEntity($service);
+    $this->assertEquals('outdated', $service->get('moderation_state')->value);
+
+    // Ensure no further messages are sent.
+    $this->cronRunHelper();
+    $this->assertEquals(2, count($this->getReminderMails()));
+    $this->assertEquals(1, count($this->getOutdatedMails()));
+  }
+
+  /**
+   * Tests user saving the service prevents further messages.
+   *
+   * @return void
+   *   -
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testUserCheckingService(): void {
+    // First simulate that enough time has passed for the first reminder and
+    // then save the service to prevent sending the first reminder.
+    $checkedDaysAgo = UpdateReminderUtility::SERVICE_LIMIT_1 + 1;
+    $service1 = $this->createServiceWithTransition('ready_to_publish', 'published', $checkedDaysAgo, TRUE);
+    $service1->set('moderation_state', 'ready_to_publish');
+    $service1->save();
+    $this->cronRunHelper();
+    $this->assertEquals(0, count($this->getReminderMails()));
+    $this->assertEquals(0, UpdateReminderUtility::getMessagesSent((int) $service1->id()));
+
+    // First ensure the first reminder is sent, then simulate that enough time
+    // has passed for the second reminder and then save the service to prevent
+    // sending the second reminder.
+    $service2 = $this->createServiceWithTransition('ready_to_publish', 'published', $checkedDaysAgo, TRUE);
+    $this->cronRunHelper();
+    $this->assertEquals(1, count($this->getReminderMails()));
+    $this->assertEquals(1, UpdateReminderUtility::getMessagesSent((int) $service2->id()));
+    $checkedDaysAgo = UpdateReminderUtility::SERVICE_LIMIT_2 + 1;
+    $this->updateService((int) $service2->id(), [], $checkedDaysAgo);
+    $service2->save();
+    $this->cronRunHelper();
+    $this->assertEquals(1, count($this->getReminderMails()));
+    $this->assertEquals(0, UpdateReminderUtility::getMessagesSent((int) $service2->id()));
+  }
+
+  /**
+   * Updates last run state.
+   *
+   * @param int $hours
+   *   Defines how many hours ago was the last run.
+   *
+   * @return void
+   *   -
+   */
+  protected function updateLastRunTimestamp(int $hours = UpdateReminderUtility::RUN_LIMIT_HOURS): void {
+    $timestamp = strtotime('-' . $hours . ' hours', \Drupal::time()->getRequestTime());
+    \Drupal::state()->set(UpdateReminderUtility::LAST_RUN_KEY, $timestamp);
+  }
+
+  /**
+   * Helper function to always run service update reminder with cron.
+   *
+   * @return void
+   *   -
+   */
+  protected function cronRunHelper(): void {
+    \Drupal::state()->delete(UpdateReminderUtility::LAST_RUN_KEY);
+    $this->cron->run();
+  }
+
+  /**
+   * Set node content as checked with past timestamp.
+   *
+   * @param int $nid
+   *   The node id.
+   *
+   * @param int $days
+   *   Defines how many days ago the node was checked.
+   *
+   * @return void
+   *   -
+   */
+  protected function setCheckedTimestamp(int $nid, int $days): void {
+    $timestamp = strtotime('-' . $days . ' days', \Drupal::time()->getRequestTime());
+    \Drupal::state()->set(UpdateReminderUtility::CHECKED_TIMESTAMP_BASE_KEY . $nid, $timestamp);
+  }
+
+  /**
+   * Creates service with randomized title.
+   *
+   * @param array $values
+   *   Array of values for service node.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   Node entity interface.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createService(array $values): EntityInterface {
+    $values += [
+      'type' => 'service',
+      'title' => $this->randomMachineName(8),
+    ];
+    $node = Node::create($values);
+    $node->save();
+    return $this->reloadEntity($node);
+  }
+
+  /**
+   * Updates service moderation state and sets changed and checked timestamps.
+   *
+   * @param int $nid
+   *   The node id.
+   * @param array $values
+   *    Array of values for service node.
+   * @param int $days
+   *   Defines how many days ago the node was changed and saved.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   Node entity interface.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function updateService(int $nid, array $values, int $days): EntityInterface {
+    $node = Node::load($nid);
+    foreach ($values as $key => $value) {
+      $node->set($key, $value);
+    }
+    $node->save();
+    $this->connection->update('node_field_data')
+      ->condition('nid', $node->id())
+      ->fields(['changed' => strtotime('-' . $days . ' days', \Drupal::time()->getRequestTime())])
+      ->execute();
+    $this->setCheckedTimestamp((int) $node->id(), $days);
+    return $this->reloadEntity($node);
+  }
+
+  /**
+   * Creates and updates a service with given moderation state transition.
+   *
+   * @param string $fromState
+   *   The initial moderation state.
+   * @param string $toState
+   *   The updated moderation state.
+   * @param int $days
+   *   Defines how many days ago the service was changed and saved.
+   * @param bool $addUser
+   *   Defines whether service provider user is added.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createServiceWithTransition(string $fromState, string $toState, int $days, bool $addUser = FALSE): EntityInterface {
+    $user = NULL;
+    if ($addUser) {
+      $user = $this->createUser([], NULL, FALSE, [
+        'mail' => $this->randomMachineName(8) . '@tpm.test',
+        'status' => 1,
+      ]);
+    }
+    $service = $this->createService([
+      'field_service_provider_updatee' => $user,
+      'moderation_state' => $fromState,
+    ]);
+    return $this->updateService((int) $service->id(), [
+      'moderation_state' => $toState
+    ], $days);
+  }
+
+  /**
+   * Gets an array containing all update remainder mails.
+   *
+   * @return array
+   *   An array containing captured email messages.
+   */
+  protected function getReminderMails(): array {
+    return $this->getMails([
+      'id' => 'message_notify_hel_tpm_update_reminder_service',
+    ]);
+  }
+
+  /**
+   * Gets an array containing all service outdated mails.
+   *
+   * @return array
+   *   An array containing captured email messages.
+   */
+  protected function getOutdatedMails(): array {
+    return $this->getMails([
+      'id' => 'message_notify_hel_tpm_update_reminder_outdated',
+    ]);
+  }
+
+}


### PR DESCRIPTION
Also fixes an entity query crash when there are no published services.

**Testing instructions:**
- [ ] Check that tests pass: `lando test public/modules/custom/hel_tpm_update_reminder/tests/`
- [ ] Check the code.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
