### PR TITLE
Hotfix TP-1349 Reverted service view reponsibile editors to not use

### DIFF
--- a/config/sync/language/en/views.view.group_services.yml
+++ b/config/sync/language/en/views.view.group_services.yml
@@ -16,7 +16,7 @@ display:
           label: Operations
         name_1:
           label: 'Responsible editor (service provider)'
-        name:
+        field_responsible_updatee:
           label: 'Responsible editor (municipality)'
       exposed_form:
         options:

--- a/config/sync/language/sv/views.view.group_services.yml
+++ b/config/sync/language/sv/views.view.group_services.yml
@@ -16,7 +16,7 @@ display:
           label: Operationer
         name_1:
           label: 'Ansvarig person hos tjänsteleverantören'
-        name:
+        field_responsible_updatee:
           label: 'Kommunens ansvarsuppdaterare'
       filters:
         moderation_state:

--- a/config/sync/views.view.group_services.yml
+++ b/config/sync/views.view.group_services.yml
@@ -3,6 +3,7 @@ langcode: fi
 status: true
 dependencies:
   config:
+    - field.storage.node.field_responsible_updatee
     - node.type.service
     - workflows.workflow.service_moderation
   module:
@@ -162,15 +163,13 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        name:
-          id: name
-          table: users_field_data
-          field: name
-          relationship: field_responsible_updatee
+        field_responsible_updatee:
+          id: field_responsible_updatee
+          table: node__field_responsible_updatee
+          field: field_responsible_updatee
+          relationship: none
           group_type: group
           admin_label: ''
-          entity_type: user
-          entity_field: name
           plugin_id: field
           label: 'Kunnan vastuupäivittäjä'
           exclude: false
@@ -205,7 +204,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -213,11 +212,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: user_name
+          click_sort_column: target_id
+          type: entity_reference_label
           settings:
-            link_to_entity: false
-          group_column: value
+            link: true
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -1099,6 +1098,7 @@ display:
         - user.group_permissions
         - 'user.node_grants:view'
       tags:
+        - 'config:field.storage.node.field_responsible_updatee'
         - 'config:workflow_list'
   page_1:
     id: page_1
@@ -1184,4 +1184,5 @@ display:
         - user.group_permissions
         - 'user.node_grants:view'
       tags:
+        - 'config:field.storage.node.field_responsible_updatee'
         - 'config:workflow_list'


### PR DESCRIPTION
relationship

**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Login as service provider editor
- [x] Confirm you can't see municipality editors in your groups service listing

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
