### PR TITLE
TP-1294 Disable tracking cookies

### DIFF
--- a/public/themes/custom/palvelumanuaali/js/matomo.js
+++ b/public/themes/custom/palvelumanuaali/js/matomo.js
@@ -5,10 +5,11 @@
       return;
     }
 
-    // Load Matomo only if statistics cookies are allowed.
-    if (Drupal.eu_cookie_compliance.hasAgreed('statistics')) {
+    // Use tracking also with essential cookie selection as it is done without tracking cookies.
+    if (Drupal.eu_cookie_compliance.hasAgreed('essential_cookies') || Drupal.eu_cookie_compliance.hasAgreed('statistics')) {
       const _paq = window._paq = window._paq || [];
-      _paq.push(["setExcludedQueryParams", ["name","pass-reset-token","destination","autologout_timeout","step","check_logged_in","fbclid","time","complianz_scan_token","complianz_id"]]);
+      _paq.push(["setExcludedQueryParams", ["name", "pass-reset-token", "destination", "autologout_timeout", "step", "check_logged_in", "fbclid", "time", "complianz_scan_token", "complianz_id"]]);
+      _paq.push(['disableCookies']);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       const d = document;


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
Before testing, note that the script is still not included for `/user` paths and admin users.

- [x] Clear existing cookie banner cookies.
- [x] Before making a selection from cookie banner, check that piwik script is _not_ loaded (using e.g. network tab from dev tools).
- [x] When selecting essential cookies, the script is loaded (after a page referesh).
- [x] When selecting all cookies, the script is loaded (after a page referesh).
- [x] When the script is loaded, there's no tracking cookies (cookie names start with `_pk`).

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
