### PR TITLE
TP-1359 Added access time for re-activated users to avoid blocking.

### DIFF
--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -77,12 +77,12 @@ function hel_tpm_user_expiry_user_update(EntityInterface $entity): void {
 
 /**
  * Force update user last access.
-
+ *
  * @param \Drupal\user\UserInterface $user
  *   User entity.
  *
  * @return void
- *  void
+ *   void
  */
 function _hel_tpm_user_expiry_update_user_last_access(UserInterface $user) {
   \Drupal::database()->update('users_field_data')

--- a/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
+++ b/public/modules/custom/hel_tpm_user_expiry/hel_tpm_user_expiry.module
@@ -71,7 +71,24 @@ function hel_tpm_user_expiry_user_update(EntityInterface $entity): void {
   if ($entity->original->isBlocked() && $entity->isActive()) {
     // Clear user expiry notification state when blocked user is set to active.
     _hel_tpm_user_expiry_delete_notified_state($entity->id());
+    _hel_tpm_user_expiry_update_user_last_access($entity);
   }
+}
+
+/**
+ * Force update user last access.
+
+ * @param \Drupal\user\UserInterface $user
+ *   User entity.
+ *
+ * @return void
+ *  void
+ */
+function _hel_tpm_user_expiry_update_user_last_access(UserInterface $user) {
+  \Drupal::database()->update('users_field_data')
+    ->fields(['access' => \Drupal::time()->getRequestTime()])
+    ->condition('uid', $user->id())
+    ->execute();
 }
 
 /**

--- a/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
+++ b/public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
@@ -289,6 +289,13 @@ final class UserExpirationTest extends EntityKernelTestBase {
     $this->assertEquals('0', $blockedUser->get('status')->value);
   }
 
+  /**
+   * Test re-activated accounts stay active for configured period of time.
+   *
+   * @return void
+   *   Void.
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
   public function testReActivatedUserStaysActive() {
     $user = $this->createLastAccessUser(2, '-220 days', 0);
     $this->assertEquals('0', $user->get('status')->value);


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush cr

**Testing instructions:**
- [x] Login
- [x] Go to user list and unblock once blocked user
- [x] Confirm last access has updated to current time.
- [x] Run: lando test public/modules/custom/hel_tpm_user_expiry/tests/src/Kernel/UserExpirationTest.php
- [x] Confirm tests pass

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
