### PR TITLE
TP-1335 Show archived but not by default

### DIFF
--- a/config/sync/language/en/views.view.group_responsibility_services.yml
+++ b/config/sync/language/en/views.view.group_responsibility_services.yml
@@ -18,6 +18,10 @@ display:
           label: 'Responsible for service in the organisation'
         name:
           label: 'Responsible for service in municipality'
+      filters:
+        moderation_state_filter_exclude_archived:
+          expose:
+            label: 'Service status'
   page_1:
     display_options:
       menu:

--- a/config/sync/language/en/views.view.group_services.yml
+++ b/config/sync/language/en/views.view.group_services.yml
@@ -26,9 +26,6 @@ display:
         status:
           group_info:
             label: Status
-        moderation_state:
-          expose:
-            label: 'Service status'
         langcode:
           expose:
             label: Language
@@ -36,6 +33,9 @@ display:
           expose:
             label: 'Filter:'
             placeholder: 'Filter by search term '
+        moderation_state_filter_exclude_archived:
+          expose:
+            label: 'Service status'
   page_1:
     display_options:
       menu:

--- a/config/sync/language/sv/views.view.group_responsibility_services.yml
+++ b/config/sync/language/sv/views.view.group_responsibility_services.yml
@@ -19,9 +19,6 @@ display:
         name:
           label: 'Kommunens ansvarsuppdaterare'
       filters:
-        moderation_state:
-          expose:
-            label: 'Tjänstens status '
         type_1:
           expose:
             label: 'Grupptyp '
@@ -32,6 +29,9 @@ display:
           expose:
             label: 'Filtrera:'
             placeholder: 'Filtrera efter sökterm'
+        moderation_state_filter_exclude_archived:
+          expose:
+            label: 'Tjänstens status'
   page_1:
     display_options:
       menu:

--- a/config/sync/language/sv/views.view.group_services.yml
+++ b/config/sync/language/sv/views.view.group_services.yml
@@ -19,9 +19,6 @@ display:
         field_responsible_updatee:
           label: 'Kommunens ansvarsuppdaterare'
       filters:
-        moderation_state:
-          expose:
-            label: 'Tjänstens status '
         langcode:
           expose:
             label: Språk
@@ -32,6 +29,9 @@ display:
         status:
           group_info:
             label: Publiceringsstatus
+        moderation_state_filter_exclude_archived:
+          expose:
+            label: 'Tjänstens status'
       exposed_form:
         options:
           text_input_required_format: ''

--- a/config/sync/views.view.group_responsibility_services.yml
+++ b/config/sync/views.view.group_responsibility_services.yml
@@ -10,6 +10,7 @@ dependencies:
     - content_moderation
     - group
     - hel_tpm_editorial
+    - hel_tpm_group
     - node
     - user
 id: group_responsibility_services
@@ -836,30 +837,31 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        moderation_state:
-          id: moderation_state
+        moderation_state_filter_exclude_archived:
+          id: moderation_state_filter_exclude_archived
           table: node_field_data
-          field: moderation_state
+          field: moderation_state_filter_exclude_archived
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          plugin_id: moderation_state_filter
+          plugin_id: moderation_state_filter_exclude_archived
           operator: in
           value:
-            all: all
+            all_exclude_archived: all_exclude_archived
             service_moderation-draft: service_moderation-draft
             service_moderation-ready_to_publish: service_moderation-ready_to_publish
             service_moderation-published: service_moderation-published
             service_moderation-outdated: service_moderation-outdated
+            service_moderation-archived: service_moderation-archived
           group: 1
           exposed: true
           expose:
-            operator_id: moderation_state_op
+            operator_id: moderation_state_filter_exclude_archived_op
             label: Muokkaustila
             description: ''
             use_operator: false
-            operator: moderation_state_op
+            operator: moderation_state_filter_exclude_archived_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: moderation_state

--- a/config/sync/views.view.group_services.yml
+++ b/config/sync/views.view.group_services.yml
@@ -13,6 +13,7 @@ dependencies:
     - group
     - hel_tpm_editorial
     - hel_tpm_general
+    - hel_tpm_group
     - node
     - user
 _core:
@@ -749,56 +750,6 @@ display:
                 title: Julkaisematon
                 operator: '='
                 value: '0'
-        moderation_state:
-          id: moderation_state
-          table: node_field_data
-          field: moderation_state
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: moderation_state_filter
-          operator: in
-          value:
-            service_moderation-draft: service_moderation-draft
-            service_moderation-ready_to_publish: service_moderation-ready_to_publish
-            service_moderation-published: service_moderation-published
-            service_moderation-outdated: service_moderation-outdated
-          group: 1
-          exposed: true
-          expose:
-            operator_id: moderation_state_op
-            label: Muokkaustila
-            description: ''
-            use_operator: false
-            operator: moderation_state_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: moderation_state
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              root: '0'
-              admin: '0'
-              editor: '0'
-              specialist: '0'
-              specialist_editor: '0'
-            reduce: true
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
         type_1:
           id: type_1
           table: node_field_data
@@ -870,6 +821,58 @@ display:
             required: false
             remember: false
             multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              root: '0'
+              admin: '0'
+              editor: '0'
+              specialist: '0'
+              specialist_editor: '0'
+            reduce: true
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        moderation_state_filter_exclude_archived:
+          id: moderation_state_filter_exclude_archived
+          table: node_field_data
+          field: moderation_state_filter_exclude_archived
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter_exclude_archived
+          operator: in
+          value:
+            all_exclude_archived: all_exclude_archived
+            service_moderation-draft: service_moderation-draft
+            service_moderation-ready_to_publish: service_moderation-ready_to_publish
+            service_moderation-published: service_moderation-published
+            service_moderation-outdated: service_moderation-outdated
+            service_moderation-archived: service_moderation-archived
+          group: 1
+          exposed: true
+          expose:
+            operator_id: moderation_state_filter_exclude_archived_op
+            label: Muokkaustila
+            description: ''
+            use_operator: false
+            operator: moderation_state_filter_exclude_archived_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: moderation_state
+            required: false
+            remember: false
+            multiple: false
             remember_roles:
               authenticated: authenticated
               anonymous: '0'

--- a/public/modules/custom/hel_tpm_group/config/schema/hel_tpm_group.schema.yml
+++ b/public/modules/custom/hel_tpm_group/config/schema/hel_tpm_group.schema.yml
@@ -28,3 +28,7 @@ views.filter.group_label_filter:
 views.filter.group_without_admin_filter:
   type: views.filter.in_operator
   label: 'Groups without admin'
+
+views.filter.moderation_state_filter_exclude_archived:
+  type: views.filter.in_operator
+  label: 'Moderation state filter exclude archived'

--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.module
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -250,6 +251,15 @@ function hel_tpm_group_views_data_alter(array &$data) {
       'field' => 'nid',
       'id' => 'group_services_missing_references',
       'zero is null' => TRUE,
+    ],
+  ];
+
+  $data['node_field_data']['moderation_state_filter_exclude_archived'] = [
+    'title' => t('Moderation state excluding archived by default'),
+    'filter' => [
+      'id' => 'moderation_state_filter_exclude_archived',
+      'field' => 'moderation_state',
+      'allow empty' => TRUE
     ],
   ];
 }

--- a/public/modules/custom/hel_tpm_group/src/Plugin/views/filter/ModerationStateExcludeArchived.php
+++ b/public/modules/custom/hel_tpm_group/src/Plugin/views/filter/ModerationStateExcludeArchived.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\hel_tpm_group\Plugin\views\filter;
+
+use Drupal\content_moderation\Plugin\views\filter\ModerationStateFilter;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a filter for the moderation state and excludes archived by default.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("moderation_state_filter_exclude_archived")
+ */
+class ModerationStateExcludeArchived extends ModerationStateFilter {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValueOptions() {
+    $parentValueOptions = parent::getValueOptions();
+    $newValueOption = [
+      'all_exclude_archived' => $this->t("– All excluding archived –"),
+    ];
+    $this->valueOptions = $newValueOption + $parentValueOptions;
+    return $this->valueOptions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function acceptExposedInput($input) {
+    if ($input['moderation_state'] === 'all_exclude_archived') {
+      return TRUE;
+    }
+    else {
+      return parent::acceptExposedInput($input);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildExposedForm(&$form, FormStateInterface $form_state): void {
+    parent::buildExposedForm($form, $form_state);
+    $form['moderation_state']['#default_value'] = 'all_exclude_archived';
+    // Remove the 'All' option.
+    unset($form['moderation_state']['#options']['All']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function opSimple() {
+    if (!empty($this->value['all_exclude_archived'])) {
+      $this->value = [
+        'service_moderation-draft' => "service_moderation-draft",
+        'service_moderation-ready_to_publish' => "service_moderation-ready_to_publish",
+        'service_moderation-published' => "service_moderation-published",
+      ];
+    }
+    parent::opSimple();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function valueForm(&$form, FormStateInterface $form_state): void {
+    parent::valueForm($form, $form_state);
+    if (!$form_state->get('exposed')) {
+      return;
+    }
+    $identifier = $this->options['expose']['identifier'];
+    $userInput = $form_state->getUserInput();
+    if (!empty($identifier) && !empty($userInput) && $userInput[$identifier] == 'All') {
+      // Replace previously set default input value.
+      $userInput[$identifier] = 'all_exclude_archived';
+      $form_state->setUserInput($userInput);
+    }
+  }
+
+}

--- a/public/modules/custom/hel_tpm_group/src/Plugin/views/filter/ModerationStateExcludeArchived.php
+++ b/public/modules/custom/hel_tpm_group/src/Plugin/views/filter/ModerationStateExcludeArchived.php
@@ -59,6 +59,7 @@ class ModerationStateExcludeArchived extends ModerationStateFilter {
         'service_moderation-draft' => "service_moderation-draft",
         'service_moderation-ready_to_publish' => "service_moderation-ready_to_publish",
         'service_moderation-published' => "service_moderation-published",
+        'service_moderation-outdated' => "service_moderation-outdated",
       ];
     }
     parent::opSimple();

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1505,3 +1505,6 @@ msgstr "Poistettu suosikeista"
 
 msgid "Group member can't be removed. The member has responsibility for the following services. Edit the services first."
 msgstr "Käyttäjää ei voida poistaa ryhmästä. Käyttäjä on määritetty vastuupäivittäjäksi seuraaviin palveluihin. Muuta ensin palveluiden tiedot."
+
+msgid "– All excluding archived –"
+msgstr "– Kaikki (pl. arkistoidut) –"

--- a/translations/sv-interface-translations.po
+++ b/translations/sv-interface-translations.po
@@ -867,3 +867,6 @@ msgstr "Läggs till i favoriter"
 
 msgid "Removed from favorites"
 msgstr "Borttagen från favoriter"
+
+msgid "– All excluding archived –"
+msgstr "– Allt exklusive arkiverat –"


### PR DESCRIPTION
Shows archived services as an moderation status filter option, but hides it from the default "All" selection.

**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
- [ ] Login and go to some group's services tab `/group/<ID>/services`.
- [ ] Checking the moderation status filter: make sure the "All excluding archived" selection is the default value.
- [ ] Ensure the "All excluding archived" option includes all other statuses than archived content.
- [ ] Ensure the other moderation status filter options work normally.
- [ ] Ensure the moderation status filter still works with other filters.
- [ ] Go to the `/group/<ID>/group-responsibility-services` tab and check that is works likewise.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
