### PR TITLE
TP-1400 Allow translating municipality taxonomy's view headers

### DIFF
--- a/config/sync/field.field.taxonomy_term.municipality.field_view_header.yml
+++ b/config/sync/field.field.taxonomy_term.municipality.field_view_header.yml
@@ -12,7 +12,7 @@ bundle: municipality
 label: 'Näkymäsivun otsikko'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
drush cim

**Testing instructions:**
- [x] Go to some municipality term page.
- [x] Translate the page if it's not already translated.
- [x] Make sure the view page header field can have different text with different translations.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
