### PR TITLE
TP-1435 Preserve parent category order

### DIFF
--- a/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/DropdownMultiselect.php
+++ b/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/DropdownMultiselect.php
@@ -3,7 +3,6 @@
 namespace Drupal\hel_tpm_search\Plugin\better_exposed_filters\filter;
 
 use Drupal\better_exposed_filters\Plugin\better_exposed_filters\filter\FilterWidgetBase;
-use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -68,6 +67,7 @@ class DropdownMultiselect extends FilterWidgetBase implements ContainerFactoryPl
     ];
     return $form;
   }
+
   /**
    * Add multiselect support for dropdown filter.
    *
@@ -110,14 +110,16 @@ class DropdownMultiselect extends FilterWidgetBase implements ContainerFactoryPl
   /**
    * Create optgroup from taxonomy terms.
    *
-   * @param $field
-   *  Select field.
+   * @param array $field
+   *   Select field.
    *
-   * @return array|void
+   * @return void
+   *   -
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  private function createOptGroups(&$field) {
+  private function createOptGroups(array &$field) {
     if ($field['#type'] !== 'select') {
       return;
     }
@@ -141,4 +143,5 @@ class DropdownMultiselect extends FilterWidgetBase implements ContainerFactoryPl
     $optgroup = array_filter($optgroup);
     $field['#options'] = $optgroup;
   }
+
 }

--- a/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/DropdownMultiselect.php
+++ b/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/DropdownMultiselect.php
@@ -124,13 +124,21 @@ class DropdownMultiselect extends FilterWidgetBase implements ContainerFactoryPl
     $optgroup = [];
     $options = $field['#options'];
     $terms = $this->entityTypeManager->getStorage('taxonomy_term')->loadMultiple(array_keys($options));
+    // Add parents first so that the parent term order is preserved.
+    foreach ($terms as $term) {
+      if (empty($term->parent->entity)) {
+        $optgroup[$term->label()] = [];
+      }
+    }
+    // Add terms to parents preserving the term order.
     foreach ($terms as $term) {
       $parent = $term->parent->entity;
-      if (empty($parent)) {
-        continue;
+      if (!empty($parent)) {
+        $optgroup[$parent->label()][$term->id()] = $term->label();
       }
-      $optgroup[$parent->label()][$term->id()] = $term->label();
     }
+    // Remove empty parents.
+    $optgroup = array_filter($optgroup);
     $field['#options'] = $optgroup;
   }
 }


### PR DESCRIPTION
**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
- [x] Open the service set taxonomy listing and the search page.
- [x] From the search page, open the serivce category  dropdown and check that the terms, both parent and child, are in the same order as in the taxonomy listing.
- [x] Check that the dropdown still works.
- [x] Check that the other search page dropdowns also work.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
