### PR TITLE
TP-1491: Disable ajax from group members view

### DIFF
--- a/config/sync/views.view.group_members.yml
+++ b/config/sync/views.view.group_members.yml
@@ -696,7 +696,7 @@ display:
           required: true
           group_content_plugins:
             group_membership: group_membership
-      use_ajax: true
+      use_ajax: false
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -717,7 +717,10 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        ajax_history:
+          enable_history: false
+          exclude_args: ''
       path: group/%group/members
       menu:
         type: tab


### PR DESCRIPTION
With ajax, a group admin without "administer users" permission was not able too see a user status field.

**Actions necessary for applying the changes:**
drush deploy

**Testing instructions:**
- [x] Login with a non-admin group admin account.
- [x] Check that group members view work:
- [x] When sorting or searching, the status column is still visible.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
