### PR TITLE
TP-1522 Do not use default start date value

### DIFF
--- a/config/sync/field.field.paragraph.service_time_and_place.field_dates.yml
+++ b/config/sync/field.field.paragraph.service_time_and_place.field_dates.yml
@@ -7,11 +7,6 @@ dependencies:
     - paragraphs.paragraphs_type.service_time_and_place
   module:
     - date_recur
-    - epp
-third_party_settings:
-  epp:
-    value: ''
-    on_update: 0
 id: paragraph.service_time_and_place.field_dates
 field_name: field_dates
 entity_type: paragraph
@@ -22,14 +17,9 @@ required: false
 translatable: false
 default_value:
   -
-    default_date_type: now
-    default_date: now
-    default_end_date_type: ''
-    default_end_date: ''
     default_date_time_zone: Europe/Helsinki
     default_time_zone: Europe/Helsinki
     default_time_zone_source: fixed
-    default_rrule: ''
 default_value_callback: ''
 settings:
   precreate: P2Y


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Edit some new or existing service.
- [x] Make sure there is place and time component.
- [x] Check "Date and time are separately agreed upon" and submit.
- [x] Check that there is no error message "Start date and end date must be provided" (as there is no longer a default value for the start date).

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
