### PR TITLE
TP-1192 Group UX fixes

### DIFF
--- a/config/sync/core.base_field_override.group.organisation.label.yml
+++ b/config/sync/core.base_field_override.group.organisation.label.yml
@@ -8,7 +8,7 @@ id: group.organisation.label
 field_name: label
 entity_type: group
 bundle: organisation
-label: Title
+label: 'Ryhmän nimi'
 description: ''
 required: true
 translatable: false

--- a/config/sync/core.base_field_override.group.service_provider.label.yml
+++ b/config/sync/core.base_field_override.group.service_provider.label.yml
@@ -8,7 +8,7 @@ id: group.service_provider.label
 field_name: label
 entity_type: group
 bundle: service_provider
-label: Name
+label: 'Ryhmän nimi'
 description: ''
 required: true
 translatable: false

--- a/config/sync/core.entity_form_display.group_content.group_content_type_a689b6d6f98cc.default.yml
+++ b/config/sync/core.entity_form_display.group_content.group_content_type_a689b6d6f98cc.default.yml
@@ -5,8 +5,6 @@ dependencies:
   config:
     - field.field.group_content.group_content_type_a689b6d6f98cc.group_roles
     - group.content_type.group_content_type_a689b6d6f98cc
-  module:
-    - path
 id: group_content.group_content_type_a689b6d6f98cc.default
 targetEntityType: group_content
 bundle: group_content_type_a689b6d6f98cc
@@ -14,7 +12,7 @@ mode: default
 content:
   entity_id:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 0
     region: content
     settings:
       match_operator: CONTAINS
@@ -24,22 +22,11 @@ content:
     third_party_settings: {  }
   group_roles:
     type: options_buttons
-    weight: 31
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  langcode:
-    type: language_select
-    weight: 2
-    region: content
-    settings:
-      include_locked: true
-    third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  langcode: true
+  path: true
   uid: true

--- a/config/sync/core.entity_form_display.group_content.organisation-group_membership.default.yml
+++ b/config/sync/core.entity_form_display.group_content.organisation-group_membership.default.yml
@@ -5,8 +5,6 @@ dependencies:
   config:
     - field.field.group_content.organisation-group_membership.group_roles
     - group.content_type.organisation-group_membership
-  module:
-    - path
 id: group_content.organisation-group_membership.default
 targetEntityType: group_content
 bundle: organisation-group_membership
@@ -14,7 +12,7 @@ mode: default
 content:
   entity_id:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 0
     region: content
     settings:
       match_operator: CONTAINS
@@ -24,22 +22,11 @@ content:
     third_party_settings: {  }
   group_roles:
     type: options_buttons
-    weight: 31
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  langcode:
-    type: language_select
-    weight: 2
-    region: content
-    settings:
-      include_locked: true
-    third_party_settings: {  }
-  path:
-    type: path
-    weight: 30
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  langcode: true
+  path: true
   uid: true

--- a/config/sync/core.entity_view_display.group_content.group_content_type_a689b6d6f98cc.default.yml
+++ b/config/sync/core.entity_view_display.group_content.group_content_type_a689b6d6f98cc.default.yml
@@ -10,16 +10,23 @@ targetEntityType: group_content
 bundle: group_content_type_a689b6d6f98cc
 mode: default
 content:
+  entity_id:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
   group_roles:
     type: entity_reference_label
     label: above
     settings:
       link: false
     third_party_settings: {  }
-    weight: -4
+    weight: 1
     region: content
 hidden:
-  entity_id: true
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true

--- a/config/sync/core.entity_view_display.group_content.organisation-group_membership.default.yml
+++ b/config/sync/core.entity_view_display.group_content.organisation-group_membership.default.yml
@@ -10,16 +10,23 @@ targetEntityType: group_content
 bundle: organisation-group_membership
 mode: default
 content:
+  entity_id:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
   group_roles:
     type: entity_reference_label
     label: above
     settings:
       link: false
     third_party_settings: {  }
-    weight: -4
+    weight: 1
     region: content
 hidden:
-  entity_id: true
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true

--- a/config/sync/group.role.organisation-insider_root.yml
+++ b/config/sync/group.role.organisation-insider_root.yml
@@ -1,0 +1,15 @@
+uuid: 317cf713-1328-447d-becf-7bc0c47ec951
+langcode: fi
+status: true
+dependencies:
+  config:
+    - group.type.organisation
+    - user.role.root
+id: organisation-insider_root
+label: 'Insider super admin'
+weight: -7
+admin: true
+scope: insider
+global_role: root
+group_type: organisation
+permissions: {  }

--- a/config/sync/group.role.service_provider-anonymous.yml
+++ b/config/sync/group.role.service_provider-anonymous.yml
@@ -7,7 +7,7 @@ dependencies:
     - user.role.anonymous
 id: service_provider-anonymous
 label: Anonyymi
-weight: -102
+weight: -9
 admin: false
 scope: outsider
 global_role: anonymous

--- a/config/sync/group.role.service_provider-editor.yml
+++ b/config/sync/group.role.service_provider-editor.yml
@@ -14,7 +14,7 @@ third_party_settings:
       specialist_editor: '0'
 id: service_provider-editor
 label: Muokkaaja
-weight: -10
+weight: -6
 admin: false
 scope: individual
 global_role: null

--- a/config/sync/group.role.service_provider-group_admin.yml
+++ b/config/sync/group.role.service_provider-group_admin.yml
@@ -14,7 +14,7 @@ third_party_settings:
       specialist_editor: '0'
 id: service_provider-group_admin
 label: 'Ryhmän pääkäyttäjä'
-weight: -9
+weight: -5
 admin: false
 scope: individual
 global_role: null

--- a/config/sync/group.role.service_provider-insider_root.yml
+++ b/config/sync/group.role.service_provider-insider_root.yml
@@ -1,15 +1,15 @@
-uuid: fcaabd96-852c-4a9c-99ae-6eaefcd64e15
+uuid: 5989018f-6c42-4857-b0b3-bb9e6cbb65e4
 langcode: fi
 status: true
 dependencies:
   config:
     - group.type.service_provider
     - user.role.root
-id: service_provider-super_admin
-label: 'Super admin'
-weight: -10
+id: service_provider-insider_root
+label: 'Insider super admin'
+weight: -7
 admin: true
-scope: outsider
+scope: insider
 global_role: root
 group_type: service_provider
 permissions: {  }

--- a/config/sync/group.role.service_provider-organization_ad.yml
+++ b/config/sync/group.role.service_provider-organization_ad.yml
@@ -14,7 +14,7 @@ third_party_settings:
       specialist: '0'
 id: service_provider-organization_ad
 label: 'Organisaation ylläpitäjä'
-weight: -8
+weight: -4
 admin: false
 scope: individual
 global_role: null

--- a/config/sync/group.role.service_provider-outsider.yml
+++ b/config/sync/group.role.service_provider-outsider.yml
@@ -7,7 +7,7 @@ dependencies:
     - user.role.authenticated
 id: service_provider-outsider
 label: Outsider
-weight: -101
+weight: -8
 admin: false
 scope: outsider
 global_role: authenticated

--- a/config/sync/group.type.organisation.yml
+++ b/config/sync/group.type.organisation.yml
@@ -7,6 +7,6 @@ label: Organisation
 description: ''
 new_revision: false
 creator_membership: true
-creator_wizard: true
+creator_wizard: false
 creator_roles:
   - organisation-administrator

--- a/config/sync/group.type.organisation.yml
+++ b/config/sync/group.type.organisation.yml
@@ -3,7 +3,7 @@ langcode: fi
 status: true
 dependencies: {  }
 id: organisation
-label: Organisation
+label: Organisaatio
 description: ''
 new_revision: false
 creator_membership: true

--- a/config/sync/group.type.service_provider.yml
+++ b/config/sync/group.type.service_provider.yml
@@ -3,7 +3,7 @@ langcode: fi
 status: true
 dependencies: {  }
 id: service_provider
-label: 'Service provider'
+label: Palveluntuottaja
 description: ''
 new_revision: false
 creator_membership: true

--- a/config/sync/language/en/group.type.organisation.yml
+++ b/config/sync/language/en/group.type.organisation.yml
@@ -1,0 +1,1 @@
+label: Organisation

--- a/config/sync/language/en/group.type.service_provider.yml
+++ b/config/sync/language/en/group.type.service_provider.yml
@@ -1,0 +1,1 @@
+label: 'Service provider'

--- a/config/sync/language/en/views.view.group_nodes.yml
+++ b/config/sync/language/en/views.view.group_nodes.yml
@@ -59,7 +59,7 @@ display:
         type:
           expose:
             label: Type
-      title: Nodes
+      title: 'Group content'
       pager:
         options:
           tags:
@@ -91,6 +91,6 @@ display:
     display_title: Page
     display_options:
       menu:
-        title: Nodes
+        title: Content
 label: 'Group nodes'
 description: 'Lists all of the nodes that have been added to a group.'

--- a/config/sync/language/sv/group.type.organisation.yml
+++ b/config/sync/language/sv/group.type.organisation.yml
@@ -1,0 +1,1 @@
+label: Organisation

--- a/config/sync/language/sv/group.type.service_provider.yml
+++ b/config/sync/language/sv/group.type.service_provider.yml
@@ -1,0 +1,1 @@
+label: Serviceproducent

--- a/config/sync/language/sv/views.view.group_nodes.yml
+++ b/config/sync/language/sv/views.view.group_nodes.yml
@@ -51,7 +51,7 @@ display:
         type:
           expose:
             label: Typ
-      title: Noder
+      title: Innehåll
       pager:
         options:
           tags:
@@ -82,5 +82,4 @@ display:
     display_title: Sida
     display_options:
       menu:
-        title: Noder
-label: 'Ryhmän solmut'
+        title: Innehåll

--- a/config/sync/views.view.group_nodes.yml
+++ b/config/sync/views.view.group_nodes.yml
@@ -1,6 +1,6 @@
 uuid: 53d4a083-94ad-4667-a208-70dbf7e46cbc
 langcode: fi
-status: false
+status: true
 dependencies:
   module:
     - gnode
@@ -23,7 +23,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Solmut
+      title: 'Ryhmän sisällöt'
       fields:
         title:
           id: title
@@ -1031,7 +1031,8 @@ display:
           group_content_plugins: {  }
       header: {  }
       footer: {  }
-      display_extenders: {  }
+      display_extenders:
+        ajax_history: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1049,14 +1050,14 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        ajax_history: {  }
       path: group/%group/nodes
       menu:
         type: tab
-        title: Solmut
+        title: Sisällöt
         description: ''
         weight: 25
-        enabled: true
         expanded: false
         menu_name: main
         parent: ''

--- a/config/sync/views.view.group_nodes.yml
+++ b/config/sync/views.view.group_nodes.yml
@@ -1,6 +1,6 @@
 uuid: 53d4a083-94ad-4667-a208-70dbf7e46cbc
 langcode: fi
-status: true
+status: false
 dependencies:
   module:
     - gnode

--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.module
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.module
@@ -292,6 +292,12 @@ function hel_tpm_group_menu_local_tasks_alter(&$data, $route_name) {
       unset($data['tabs'][0]['group.version_history']);
     }
 
+    // Remove the 'All entities' tab as its content is already shown at other
+    // group pages. It were only visible for the super admin group roles.
+    if (isset($data['tabs'][0]['group.content'])) {
+      unset($data['tabs'][0]['group.content']);
+    }
+
     // Remove revision tab if group's revisions are turned off.
     $config = \Drupal::service('config.factory')->get($entity->getEntityTypeId() . '.type.' . $entity->bundle());
     if (!$config->get('new_revision')) {

--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.module
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.module
@@ -281,6 +281,28 @@ function hel_tpm_group_page_attachments_alter(array &$attachments): void {
 }
 
 /**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function hel_tpm_group_menu_local_tasks_alter(&$data, $route_name) {
+  $entity = \Drupal::routeMatch()->getParameter('group');
+  if ($entity instanceof GroupInterface) {
+    // Remove the duplicate revision tab. Local task 'group.version_history'
+    // will be replaced by 'entity.version_history:group.version_history'.
+    if (isset($data['tabs'][0]['group.version_history'])) {
+      unset($data['tabs'][0]['group.version_history']);
+    }
+
+    // Remove revision tab if group's revisions are turned off.
+    $config = \Drupal::service('config.factory')->get($entity->getEntityTypeId() . '.type.' . $entity->bundle());
+    if (!$config->get('new_revision')) {
+      if (isset($data['tabs'][0]['entity.version_history:group.version_history'])) {
+        unset($data['tabs'][0]['entity.version_history:group.version_history']);
+      }
+    }
+  }
+}
+
+/**
  * Helper function to get valid site roles for selection.
  *
  * @return array


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Login as root user (other than uid 1)
- [x] Create a new organisation group.
- [x] After the group creation, the user is directly redirected to the group page and user can access it.
- [x] Go to `/group/<ID>/subgroups2` page and make sure user can add and create service providers.
- [x] Go to edit some group membership: the path alias field is not shown anymore.
- [x] The user name field is shown at the membership view page.
- [x] At the group page, the "All entities" tab is hidden.
- [x] At the group page, the "Nodes" tab is now "Contents".
- [x] The two duplicate revision tabs are now both hidden.
- [x] Login as some group admin user (other than root user)
- [x] Make sure group page looks ok for that user also.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
