### PR TITLE
TP-1589 Temporary fixed drupal core problem original translation revi…

### DIFF
--- a/public/modules/custom/service_manual_workflow/service_manual_workflow.module
+++ b/public/modules/custom/service_manual_workflow/service_manual_workflow.module
@@ -13,6 +13,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\field\FieldConfigInterface;
+use Drupal\node\NodeInterface;
 use Drupal\service_manual_workflow\Event\ServiceModerationEvent;
 
 /**
@@ -21,6 +22,30 @@ use Drupal\service_manual_workflow\Event\ServiceModerationEvent;
 function service_manual_workflow_cron() {
   _service_manual_workflow_queue_services_for_archival();
 }
+
+/**
+ * Implements hook_ENTITY_presave().
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *
+ * @throws \Exception
+ */
+function service_manual_workflow_node_presave(EntityInterface $entity) {
+  $default_language = \Drupal::languageManager()->getDefaultLanguage()->getId();
+  $active_langcode = $entity->language()->getId();
+
+  if ($entity instanceof NodeInterface && $entity->isTranslatable() && !$entity->isNew() && ($active_langcode !== $default_language)) {
+    $translations = $entity->getTranslationLanguages();
+    foreach ($translations as $translation_langcode => $translation_language) {
+      // Prevent secondary languages from disrupting other translations.
+      if ($translation_langcode !== $active_langcode) {
+        $translation = $entity->getTranslation($translation_language->getId());
+        $translation->setRevisionTranslationAffected(FALSE);
+      }
+    }
+  }
+}
+
 
 /**
  * Helper function to queue service items.

--- a/public/modules/custom/service_manual_workflow/service_manual_workflow.module
+++ b/public/modules/custom/service_manual_workflow/service_manual_workflow.module
@@ -31,10 +31,9 @@ function service_manual_workflow_cron() {
  * @throws \Exception
  */
 function service_manual_workflow_node_presave(EntityInterface $entity) {
-  $default_language = \Drupal::languageManager()->getDefaultLanguage()->getId();
-  $active_langcode = $entity->language()->getId();
 
-  if ($entity instanceof NodeInterface && $entity->isTranslatable() && !$entity->isNew() && ($active_langcode !== $default_language)) {
+  if ($entity instanceof NodeInterface && $entity->isTranslatable() && !$entity->isNew() && !$entity->isDefaultTranslation()) {
+    $active_langcode = $entity->language()->getId();
     $translations = $entity->getTranslationLanguages();
     foreach ($translations as $translation_langcode => $translation_language) {
       // Prevent secondary languages from disrupting other translations.


### PR DESCRIPTION
…sion overriding when changing moderation state for translated revision.

**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Create or edit service as draft
- [x] Publish service and move it back as draft
- [x] Create translation and save it as draft
- [x] Confirm original language revision is still draft
- [x] Edit translation, change moderation state to some state ie. ready to publish and save
- [x] Confirm original language revision is still draft
- [x] Save both translations as ready to publish
- [x] Confirm group publish stats list both revisions

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
