### PR TITLE
TP-1609 Fix cron error when groups have revisions

### DIFF
--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.module
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.module
@@ -46,9 +46,9 @@ function _hel_tpm_group_create_missing_updatees_queue_items() {
   $query = \Drupal::entityTypeManager()->getStorage('group')->getQuery();
   $query->accessCheck(FALSE);
   $groups = $query->execute();
-  foreach ($groups as $gid => $group) {
+  foreach ($groups as $revision_id => $entity_id) {
     $queue = \Drupal::queue('hel_tpm_group_service_missing_updatees_queue');
-    $queue->createItem(['gid' => $gid]);
+    $queue->createItem(['gid' => (int) $entity_id]);
   }
   \Drupal::state()->get('hel_tpm_group.missing_updatees_last_run', \Drupal::time()->getRequestTime());
 }


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush cr

**Testing instructions:**
- [x] First, reproduce the error before using this fix.
- [x] Create new revisions for some groups.
- [x] Clear cron queue: `lando drush queue:delete hel_tpm_group_service_missing_updatees_queue`
- [x] Running `lando drush cron` should crash.
- [x] Checkout this fix.
- [x] Clear cron queue: `lando drush queue:delete hel_tpm_group_service_missing_updatees_queue`
- [x] Now, running `lando drush cron` should _not_ crash.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
