### PR TITLE
TP-1615 Remove 'Service RTB publish' view from group services page

### DIFF
--- a/config/sync/views.view.group_services.yml
+++ b/config/sync/views.view.group_services.yml
@@ -5,8 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_responsible_updatee
     - node.type.service
-    - views.view.service_rtb_publish_stats
-    - workflows.workflow.service_moderation
   module:
     - better_exposed_filters
     - content_moderation
@@ -1083,31 +1081,7 @@ display:
           admin_label: ''
           plugin_id: hel_tpm_general_add_service_button
           empty: false
-      footer:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text
-          empty: false
-          content:
-            value: '<h3>Julkaisua odottavat palvelut</h3>'
-            format: filtered_html
-          tokenize: false
-        view:
-          id: view
-          table: views
-          field: view
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: view
-          empty: false
-          view_to_insert: 'service_rtb_publish_stats:block_2'
-          inherit_arguments: true
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Go to organization group's service page: `/group/<GID>/services`
- [x] Check that at the bottom of the page there is no "Julkaisua odottavat palvelut" title or listing.
- [x] If there's some services ready to be published those can still be found e.g. at the group view page.

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
