### PR TITLE
TP-1617 Removed current state column from ready to publish lists

### DIFF
--- a/config/sync/language/en/views.view.group_content_ready_to_publish_revisions.yml
+++ b/config/sync/language/en/views.view.group_content_ready_to_publish_revisions.yml
@@ -4,8 +4,6 @@ display:
       fields:
         title:
           label: Service
-        hel_tpm_editorial_service_has_unpublished_changes:
-          label: Changes
         edit_node:
           label: Operations
           text: Edit

--- a/config/sync/language/sv/views.view.group_content_ready_to_publish_revisions.yml
+++ b/config/sync/language/sv/views.view.group_content_ready_to_publish_revisions.yml
@@ -4,8 +4,6 @@ display:
       fields:
         title:
           label: Tjänst
-        hel_tpm_editorial_service_has_unpublished_changes:
-          label: 'Nya ändringar'
         edit_node:
           label: Operationer
           text: redigera

--- a/config/sync/views.view.group_content_ready_to_publish_revisions.yml
+++ b/config/sync/views.view.group_content_ready_to_publish_revisions.yml
@@ -13,7 +13,6 @@ dependencies:
     - content_moderation
     - eva
     - group
-    - hel_tpm_editorial
     - node
     - user
 id: group_content_ready_to_publish_revisions
@@ -96,55 +95,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        hel_tpm_editorial_service_has_unpublished_changes:
-          id: hel_tpm_editorial_service_has_unpublished_changes
-          table: views
-          field: hel_tpm_editorial_service_has_unpublished_changes
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: hel_tpm_editorial_service_has_unpublished_changes
-          label: 'Uusia muutoksia'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
         gid:
           id: gid
           table: group_relationship_field_data
@@ -564,6 +514,7 @@ display:
         - 'user.node_grants:view'
         - user.roles
       tags:
+        - 'config:field.storage.node.field_days_since_last_state_chan'
         - 'config:workflow_list'
   entity_view_2:
     id: entity_view_2


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [x] Login and go to /hallinta-ja-yllapito
- [x] Confirm "Changes" column is not show in services ready to publish view
- [x] Go to group
- [x] Confirm "Changes" column is not show in services ready to publish view

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
