### PR TITLE
TP-1647 TP-1663 Fix altering access for leaving group

### DIFF
--- a/public/modules/custom/hel_tpm_group/tests/src/Functional/LeaveGroupTest.php
+++ b/public/modules/custom/hel_tpm_group/tests/src/Functional/LeaveGroupTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\Tests\hel_tpm_group\Functional;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Tests\group\Functional\GroupBrowserTestBase;
+use Drupal\group\Entity\Group;
+use Drupal\group\PermissionScopeInterface;
+use Drupal\user\RoleInterface;
+
+/**
+ * Tests leaving group access.
+ *
+ * @coversDefaultClass \Drupal\hel_tpm_group\Plugin\Group\RelationHandler\LeaveGroupAccessControl
+ * @group group
+ */
+class LeaveGroupTest extends GroupBrowserTestBase {
+  use StringTranslationTrait;
+
+  /**
+   * Required modules.
+   *
+   * @var string[]
+   */
+  protected static $modules = [
+    'group',
+    'group_test_config',
+    'hel_tpm_group',
+    'message_notify',
+    'views',
+  ];
+
+  /**
+   * The group we will use to test methods on.
+   *
+   * @var \Drupal\group\Entity\Group
+   */
+  protected Group $group;
+
+  /**
+   * Global permissions.
+   *
+   * @return string[]
+   *   Array of permissions.
+   */
+  protected function getGlobalPermissions(): array {
+    return [
+      'view the administration theme',
+      'access administration pages',
+      'access group overview',
+      'create default group',
+      'administer group',
+      'administer users',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->setUpAccount();
+
+    $this->group = $this->createGroup(['type' => $this->createGroupType()->id()]);
+  }
+
+  /**
+   * Check access to 'Remove member' action.
+   *
+   * @todo Add support for testing the 'leave group' permission.
+   *
+   * @dataProvider provideLeavingGroupScenarios
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testLeavingGroup($permissions = []) {
+    $this->createGroupRole([
+      'group_type' => $this->group->bundle(),
+      'scope' => PermissionScopeInterface::INSIDER_ID,
+      'global_role' => RoleInterface::AUTHENTICATED_ID,
+      'permissions' => $permissions,
+    ]);
+
+    // Add extra users.
+    $this->group->addMember($this->createUser());
+    $this->group->addMember($this->createUser());
+    $this->group->save();
+
+    $this->drupalGet('/group/' . $this->group->id() . '/members');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $page = $this->getSession()->getPage();
+    $memberTableRows = $page->findAll('css', 'main table tbody tr');
+    foreach ($memberTableRows as $row) {
+      $userName = $row->find('css', 'td.views-field-name')->getText();
+      $removeLink = $row->find('css', 'td.views-field-dropbutton')->findLink('Remove member');
+      if ($userName === $this->groupCreator->getAccountName()) {
+        $this->assertNull($removeLink);
+      }
+      else {
+        $this->assertNotNull($removeLink);
+      }
+    }
+  }
+
+  /**
+   * Data provider for testLeavingGroup().
+   */
+  public function provideLeavingGroupScenarios() {
+    $scenarios['canNotLeaveGroup'] = [
+      [
+        'view group',
+        'edit group',
+        'delete group',
+        'administer members',
+      ],
+    ];
+
+    return $scenarios;
+  }
+
+}


### PR DESCRIPTION
Read the commit message for description.

**Actions necessary for applying the changes:**
`lando drush deploy`

**Testing instructions:**

 _Testing removing group members_

- [x] Use group admin user, who does not have site admin permissions.
- [x] Go to /group/[GID]/members
- [x] As a group admin, add a member to the group.
- [x] Make sure there are also members added by another group admin.
- [x] Check that group admin can remove all other members (including other group admins) from the group, despite who has added them.
- [x] Check that group admin can not leave the group themself.

_Testing removing group members_

- [x] Use group admin user, who has site admin permissions.
- [x] Go to /group/[GID]/subgroups
- [x] Create a new subgroup to the group.
- [x] Make sure you can remove all subgroup relations, including the one just created ("Remove from service providers").

_Testing removing content_

- [x] Use group admin user, who has site admin permissions.
- [x] Go to /group/[GID]/nodes
- [x] Add new service content to the group.
- [x] Make sure you can remove the content relation ("Delete relation").

**Review checklist:**
- [x] The code conforms to Drupal coding standards
- [x] I have reviewed the code for security and quality issues
- [x] I have tested the code with the proper **user** roles
