### PR TITLE
TP-1664 Allow anonymous users to view the age field

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -33,6 +33,7 @@ permissions:
   - 'use search_api_autocomplete for solr_service_search'
   - 'use text format plain_text_format'
   - 'view contact info'
+  - 'view field_age'
   - 'view field_service_radioactivity'
   - 'view media'
   - 'view own field_service_radioactivity'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -11,6 +11,7 @@ dependencies:
     - content_moderation
     - entity_print_views
     - eu_cookie_compliance
+    - field_permissions
     - file
     - filter
     - flag
@@ -43,6 +44,7 @@ permissions:
   - 'use service_moderation transition ready_to_publish_to_draft'
   - 'use text format plain_text_format'
   - 'view contact info'
+  - 'view field_age'
   - 'view flag lists'
   - 'view media'
   - 'view own unpublished content'


### PR DESCRIPTION
**Actions necessary for applying the changes:**

lando drush deploy

**Testing instructions:**
- [x] As an anonymous user, go to a service page that has some age range set.
- [x] Check that you can view the set age range.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
