### PR TITLE
TP-1692 Fix declaring optional parameter before required parameter

### DIFF
--- a/public/modules/custom/hel_tpm_group/src/Plugin/EntityReferenceSelection/GroupUserSelection.php
+++ b/public/modules/custom/hel_tpm_group/src/Plugin/EntityReferenceSelection/GroupUserSelection.php
@@ -79,13 +79,13 @@ class GroupUserSelection extends UserSelection {
     ModuleHandlerInterface $module_handler,
     AccountInterface $current_user,
     Connection $connection,
-    ?EntityFieldManagerInterface $entity_field_manager = NULL,
-    ?EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
-    ?EntityRepositoryInterface $entity_repository = NULL,
     GroupMembershipLoaderInterface $group_membership_loader,
     GroupStateTransitionValidation $group_state_transition_validator,
     GroupHierarchyManagerInterface $group_hierarchy_manager,
     RouteMatchInterface $route_match,
+    ?EntityFieldManagerInterface $entity_field_manager = NULL,
+    ?EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
+    ?EntityRepositoryInterface $entity_repository = NULL,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $module_handler, $current_user, $connection, $entity_field_manager, $entity_type_bundle_info, $entity_repository);
 
@@ -107,13 +107,13 @@ class GroupUserSelection extends UserSelection {
       $container->get('module_handler'),
       $container->get('current_user'),
       $container->get('database'),
-      $container->get('entity_field.manager'),
-      $container->get('entity_type.bundle.info'),
-      $container->get('entity.repository'),
       $container->get('group.membership_loader'),
       $container->get('gcontent_moderation.state_transition_validation'),
       $container->get('ggroup.group_hierarchy_manager'),
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('entity_field.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity.repository'),
     );
   }
 

--- a/public/modules/custom/hel_tpm_group/src/Plugin/EntityReferenceSelection/ParentGroupSelection.php
+++ b/public/modules/custom/hel_tpm_group/src/Plugin/EntityReferenceSelection/ParentGroupSelection.php
@@ -46,7 +46,19 @@ class ParentGroupSelection extends GroupSelection {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, EntityFieldManagerInterface $entity_field_manager, ?EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, EntityRepositoryInterface $entity_repository, GroupHierarchyManagerInterface $group_hierarchy_manager, RouteMatchInterface $route_match) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    ModuleHandlerInterface $module_handler,
+    AccountInterface $current_user,
+    EntityFieldManagerInterface $entity_field_manager,
+    EntityRepositoryInterface $entity_repository,
+    GroupHierarchyManagerInterface $group_hierarchy_manager,
+    RouteMatchInterface $route_match,
+    ?EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $module_handler, $current_user, $entity_field_manager, $entity_type_bundle_info, $entity_repository);
     $this->groupHierarchyManager = $group_hierarchy_manager;
     $this->routeMatch = $route_match;
@@ -64,10 +76,10 @@ class ParentGroupSelection extends GroupSelection {
       $container->get('module_handler'),
       $container->get('current_user'),
       $container->get('entity_field.manager'),
-      $container->get('entity_type.bundle.info'),
       $container->get('entity.repository'),
       $container->get('ggroup.group_hierarchy_manager'),
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('entity_type.bundle.info')
     );
   }
 


### PR DESCRIPTION
Since PHP 8.0, when declaring a function, adding a required parameter after optional parameters is deprecated.

**Actions necessary for applying the changes:**
lando drush cr

**Testing instructions:**
- [x] Before pulling changes, edit a serivice and make sure to see debug message telling that optional parameter is declared before required parameter.
- [x] Pull the changes and those debug messages are gone.
- [ ] The edit form still works.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
