### PR TITLE
TP-1726 Fix permissions for rtp lists

### DIFF
--- a/config/sync/views.view.group_content_ready_to_publish_revisions.yml
+++ b/config/sync/views.view.group_content_ready_to_publish_revisions.yml
@@ -6,16 +6,12 @@ dependencies:
     - field.storage.node.field_days_since_last_state_chan
     - field.storage.node.field_responsible_updatee
     - node.type.service
-    - user.role.admin
-    - user.role.root
-    - user.role.specialist_editor
     - workflows.workflow.service_moderation
   module:
     - content_moderation
     - eva
     - group
     - node
-    - user
 id: group_content_ready_to_publish_revisions
 label: 'Group content ready to publish (revisions)'
 module: views
@@ -299,12 +295,9 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: role
+        type: group_permission
         options:
-          role:
-            root: root
-            admin: admin
-            specialist_editor: specialist_editor
+          group_permission: 'view unpublished group_node:service entity'
       cache:
         type: time
         options:
@@ -572,9 +565,10 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.roles
       tags:
         - 'config:field.storage.node.field_days_since_last_state_chan'
         - 'config:field.storage.node.field_responsible_updatee'
@@ -598,9 +592,10 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.roles
       tags:
         - 'config:field.storage.node.field_days_since_last_state_chan'
         - 'config:field.storage.node.field_responsible_updatee'
@@ -625,9 +620,10 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - route
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.roles
       tags:
         - 'config:field.storage.node.field_days_since_last_state_chan'
         - 'config:field.storage.node.field_responsible_updatee'

--- a/config/sync/views.view.service_rtb_publish_stats.yml
+++ b/config/sync/views.view.service_rtb_publish_stats.yml
@@ -927,6 +927,10 @@ display:
         type: none
         options:
           offset: 0
+      access:
+        type: group_permission
+        options:
+          group_permission: 'view unpublished group_node:service entity'
       empty:
         area_text_custom:
           id: area_text_custom
@@ -976,6 +980,7 @@ display:
           not: false
       defaults:
         empty: false
+        access: false
         pager: false
         relationships: false
         fields: false
@@ -1015,8 +1020,9 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - route.group
         - url
+        - user.group_permissions
         - 'user.node_grants:view'
-        - user.permissions
       tags:
         - 'config:workflow_list'


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Login as admin.
- [x] Check that you can see the "Services awaiting publishing" table content in group view pages.
- [x] Check that you can see the "Services waiting for publishing" table content in `/group/GID/group-responsibility-services` pages.
- [x] Login as group editor (a member in the group) and re-check:
- [x] Check that you can see the "Services awaiting publishing" table content in group view pages.
- [x] Check that you can see the "Services waiting for publishing" table content in `/group/GID/group-responsibility-services` pages.
- [x] Login as another group's editor and check:
- [x] Check that you can _not_ see the "Services awaiting publishing" table content in the original group view pages.
- [x] Check that you can _not_ see the "Services waiting for publishing" table content in the original `/group/GID/group-responsibility-services` pages.
- [x] Logout and re-check:
- [x] Check that you can _not_ see the "Services awaiting publishing" table content in group view pages.
- [x] Check that you can _not_ see the "Services waiting for publishing" table content in `/group/GID/group-responsibility-services` pages.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
