### PR TITLE
TP-1747 Add group from relationship to empty municipality field

### DIFF
--- a/public/modules/custom/hel_tpm_group/hel_tpm_group.module
+++ b/public/modules/custom/hel_tpm_group/hel_tpm_group.module
@@ -108,6 +108,7 @@ function hel_tpm_group_entity_field_access($operation, FieldDefinitionInterface 
  * Implements hook_ENTITY_insert().
  */
 function hel_tpm_group_group_content_insert(EntityInterface $entity): void {
+  _hel_tpm_group_add_responsible_municipality($entity);
   _hel_tpm_group_invalidate_service_provider_member_cache($entity);
 }
 
@@ -153,6 +154,45 @@ function _hel_tpm_group_invalidate_service_provider_member_cache(EntityInterface
     \Drupal::service('cache_tags.invalidator')->invalidateTags([
       'group_content_list:plugin:group_membership:entity:' . $member->getUser()->id(),
     ]);
+  }
+}
+
+/**
+ * Add group from relationship to empty responsible municipality field.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The GroupRelationship entity.
+ *
+ * @return void
+ *   Void.
+ */
+function _hel_tpm_group_add_responsible_municipality(EntityInterface $entity): void {
+  if (!$entity instanceof GroupRelationship) {
+    return;
+  }
+  if ($entity->getPluginId() !== 'subgroup:service_provider') {
+    return;
+  }
+
+  $parentId = $entity->getGroupId();
+  $subgroup = $entity->getEntity();
+  if (!$services = $subgroup->getRelatedEntities('group_node:service')) {
+    return;
+  }
+
+  // Check each subgroup service and add the group from the relationship as a
+  // responsible municipality value if the field is empty.
+  foreach ($services as $service) {
+    $municipalityValue = $service->get('field_responsible_municipality')->getValue();
+    if (!empty($municipalityValue) || !is_array($municipalityValue)) {
+      continue;
+    }
+
+    $municipalityValue[] = [
+      'target_id' => $parentId,
+    ];
+    $service->set('field_responsible_municipality', $municipalityValue);
+    $service->save();
   }
 }
 


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Make sure you have a service provider group with existing services.
- [x] Remove that service provider from all municipality groups (by removing the relationship between the groups).
- [x] Make sure the services of that service provider now have empty responsible municipality fields.
- [x] Add the service provider to some municipality group (by adding a relationship between the groups).
- [x] Make sure that municipality group is now selected value in the services' responsible municipality fields.
- [x] Add the service provider to another municipality group (by adding a relationship between the groups).
- [x] Make sure the previously checked services haven't changed and the new group is not added to the responsible municipality fields.
- [x] However, it's possible to select the added group from the dropdown.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
