### PR TITLE
TP-1727 Show only published services on favorite list

### DIFF
--- a/config/sync/views.view.cart.yml
+++ b/config/sync/views.view.cart.yml
@@ -9,8 +9,10 @@ dependencies:
     - field.storage.node.field_service_producer
     - flag.flag.cart
     - node.type.service
+    - workflows.workflow.service_moderation
   module:
     - better_exposed_filters
+    - content_moderation
     - entity_print_views
     - flag
     - node
@@ -380,6 +382,47 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value:
+            service_moderation-published: service_moderation-published
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -435,10 +478,13 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_description'
+        - 'config:workflow_list'
+        - flag.flag.cart
   favorites_block:
     id: favorites_block
     display_title: Lohko
@@ -871,10 +917,13 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_service_producer'
+        - 'config:workflow_list'
+        - flag.flag.cart
   page_1:
     id: page_1
     display_title: Page
@@ -1014,7 +1063,10 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_description'
+        - 'config:workflow_list'
+        - flag.flag.cart


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Find some published, ready to publish, draft, outdated and archived services.
- [x] Add those services to favorites.
- [x] Go to the services page.
- [x] Check that only those services are visible which have active published state (e.g. services are published or they are ready to publish or draft with existing previous published state).
- [x] Check that same applies for "Recently added favorites" list.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
