### PR TITLE
TP-1440 Basic page paragraph translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,6 +143,7 @@
         "drupal/notification_message": "^1.x-dev",
         "drupal/other_view_filter": "^1.2",
         "drupal/paragraphs": "^1.12",
+        "drupal/paragraphs_asymmetric_translation_widgets": "^1.4",
         "drupal/password_policy": "^4.0",
         "drupal/pathauto": "^1.8",
         "drupal/purge": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55466802b4758bc9eeec27378669c0e3",
+    "content-hash": "c84316743d8f277b904fc2925f6f0760",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",
@@ -8080,6 +8080,77 @@
             "homepage": "https://www.drupal.org/project/paragraphs",
             "support": {
                 "source": "https://git.drupalcode.org/project/paragraphs"
+            }
+        },
+        {
+            "name": "drupal/paragraphs_asymmetric_translation_widgets",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/paragraphs_asymmetric_translation_widgets.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/paragraphs_asymmetric_translation_widgets-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "3b09fb13d2bd0bb351cf98fdae1b27eab8032984"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10 || ^11",
+                "drupal/paragraphs": "~1.15"
+            },
+            "require-dev": {
+                "drupal/entity_browser": "2.x-dev",
+                "drupal/entity_usage": "2.x-dev",
+                "drupal/paragraphs": "*",
+                "drupal/search_api": "~1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1726511423",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "efpapado",
+                    "homepage": "https://www.drupal.org/user/1009348"
+                },
+                {
+                    "name": "esolitos",
+                    "homepage": "https://www.drupal.org/user/1567500"
+                },
+                {
+                    "name": "grayle",
+                    "homepage": "https://www.drupal.org/user/3145497"
+                },
+                {
+                    "name": "penyaskito",
+                    "homepage": "https://www.drupal.org/user/959536"
+                },
+                {
+                    "name": "rajab natshah",
+                    "homepage": "https://www.drupal.org/user/1414312"
+                },
+                {
+                    "name": "weseze",
+                    "homepage": "https://www.drupal.org/user/417521"
+                }
+            ],
+            "description": "Extends the paragraphs field widgets to support asymmetric translations.",
+            "homepage": "https://www.drupal.org/project/paragraphs_asymmetric_translation_widgets",
+            "support": {
+                "source": "https://git.drupalcode.org/project/paragraphs_asymmetric_translation_widgets"
             }
         },
         {

--- a/config/sync/core.base_field_override.paragraph.content.created.yml
+++ b/config/sync/core.base_field_override.paragraph.content.created.yml
@@ -11,7 +11,7 @@ bundle: content
 label: Luotu
 description: 'The time that the Paragraph was created.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/sync/core.base_field_override.paragraph.content.status.yml
+++ b/config/sync/core.base_field_override.paragraph.content.status.yml
@@ -11,7 +11,7 @@ bundle: content
 label: Julkaistu
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 1

--- a/config/sync/core.entity_form_display.node.basic_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_page.default.yml
@@ -10,8 +10,8 @@ dependencies:
     - node.type.basic_page
   module:
     - field_group
-    - hel_tpm_editorial
     - media_library
+    - paragraphs
     - path
     - select2
 third_party_settings:
@@ -83,7 +83,7 @@ content:
       match_limit: 10
     third_party_settings: {  }
   field_paragraph:
-    type: hel_tpm_editorial_paragraphs_alt_custom
+    type: paragraphs
     weight: 5
     region: content
     settings:
@@ -92,15 +92,14 @@ content:
       edit_mode: closed
       closed_mode: summary
       autocollapse: all
-      closed_mode_threshold: '0'
+      closed_mode_threshold: 0
       add_mode: modal
       form_display_mode: default
       default_paragraph_type: _none
-      add_label: ''
       features:
-        duplicate: 0
-        collapse_edit_all: 0
-        add_above: 0
+        add_above: '0'
+        collapse_edit_all: '0'
+        duplicate: '0'
     third_party_settings: {  }
   langcode:
     type: language_select

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -131,6 +131,7 @@ module:
   options: 0
   other_view_filter: 0
   page_cache: 0
+  paragraphs_asymmetric_translation_widgets: 0
   paragraphs_type_permissions: 0
   password_policy_length: 0
   password_policy_username: 0

--- a/config/sync/field.field.paragraph.content_alt_editor.field_body_alt.yml
+++ b/config/sync/field.field.paragraph.content_alt_editor.field_body_alt.yml
@@ -15,7 +15,7 @@ bundle: content_alt_editor
 label: Body
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.content_alt_editor.field_title.yml
+++ b/config/sync/field.field.paragraph.content_alt_editor.field_title.yml
@@ -12,7 +12,7 @@ bundle: content_alt_editor
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/sync/field.field.paragraph.link_card_row.field_linklist_card.yml
+++ b/config/sync/field.field.paragraph.link_card_row.field_linklist_card.yml
@@ -15,7 +15,7 @@ bundle: link_card_row
 label: Linkkinostokortti
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.link_card_with_image.field_lift_image.yml
+++ b/config/sync/field.field.paragraph.link_card_with_image.field_lift_image.yml
@@ -13,7 +13,7 @@ bundle: link_card_with_image
 label: Nostokuva
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.link_card_with_image.field_short_description.yml
+++ b/config/sync/field.field.paragraph.link_card_with_image.field_short_description.yml
@@ -12,7 +12,7 @@ bundle: link_card_with_image
 label: 'Short description'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/sync/field.field.paragraph.link_card_with_image.field_single_link.yml
+++ b/config/sync/field.field.paragraph.link_card_with_image.field_single_link.yml
@@ -14,7 +14,7 @@ bundle: link_card_with_image
 label: Linkki
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.link_card_with_image.field_title.yml
+++ b/config/sync/field.field.paragraph.link_card_with_image.field_title.yml
@@ -12,7 +12,7 @@ bundle: link_card_with_image
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/sync/field.field.paragraph.quick_link_row.field_quick_link_row.yml
+++ b/config/sync/field.field.paragraph.quick_link_row.field_quick_link_row.yml
@@ -15,7 +15,7 @@ bundle: quick_link_row
 label: Pikalinkit
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.url_and_file.field_file.yml
+++ b/config/sync/field.field.paragraph.url_and_file.field_file.yml
@@ -6,7 +6,14 @@ dependencies:
     - field.storage.paragraph.field_file
     - paragraphs.paragraphs_type.url_and_file
   module:
+    - content_translation
     - file
+third_party_settings:
+  content_translation:
+    translation_sync:
+      target_id: target_id
+      display: display
+      description: description
 id: paragraph.url_and_file.field_file
 field_name: field_file
 entity_type: paragraph
@@ -14,7 +21,7 @@ bundle: url_and_file
 label: 'Liitetiedostot (valinnainen)'
 description: "Suurin sallittu tiedoston koko on 50 Mb.\r\nTätä suuremmat videotiedostot on linkitettävä jonkin toisen videopalvelun kautta. \r\nHuomioithan, että palvelun tietojen tulee olla saavutettavia. Saavutettavissa videotallenteissa on tekstitykset sekä sisällön kuvailu."
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/field.field.paragraph.url_and_file.field_link.yml
+++ b/config/sync/field.field.paragraph.url_and_file.field_link.yml
@@ -14,7 +14,7 @@ bundle: url_and_file
 label: Link
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/sync/language.content_settings.paragraph.content_alt_editor.yml
+++ b/config/sync/language.content_settings.paragraph.content_alt_editor.yml
@@ -8,11 +8,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: paragraph.content_alt_editor
 target_entity_type_id: paragraph
 target_bundle: content_alt_editor
-default_langcode: site_default
-language_alterable: false
+default_langcode: current_interface
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.link_card_row.yml
+++ b/config/sync/language.content_settings.paragraph.link_card_row.yml
@@ -8,11 +8,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: paragraph.link_card_row
 target_entity_type_id: paragraph
 target_bundle: link_card_row
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.link_card_with_image.yml
+++ b/config/sync/language.content_settings.paragraph.link_card_with_image.yml
@@ -8,11 +8,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: paragraph.link_card_with_image
 target_entity_type_id: paragraph
 target_bundle: link_card_with_image
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/sync/language.content_settings.paragraph.url_and_file.yml
+++ b/config/sync/language.content_settings.paragraph.url_and_file.yml
@@ -8,11 +8,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: paragraph.url_and_file
 target_entity_type_id: paragraph
 target_bundle: url_and_file
-default_langcode: site_default
-language_alterable: false
+default_langcode: current_interface
+language_alterable: true


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando composer install && lando drush deploy

**Testing instructions:**
- [x] Create some basic page content with lots of different paragraph content.
- [x] Translate the page and make sure you can translat all the different paragraph content.
- [x] At the translated page, you can move, add and remove paragraph independently.
- [x] Check that paragraph translations at services are not affected.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
