### PR TITLE
TP-1737 Link service name to Latest tab and add missing edit column

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -296,8 +296,8 @@
                 "Unable to change non-translatable field value on translatable content with content moderation enabled (https://www.drupal.org/project/drupal/issues/2955321)": "https://www.drupal.org/files/issues/2024-04-16/2955321-77.patch",
                 "One time login link expiration (https://www.drupal.org/project/drupal/issues/3097238#comment-15374828)": "https://www.drupal.org/files/issues/2024-06-21/3097238-initial-reset-harden-35.patch",
                 "ContentEntityBase::hasTranslationChanges will compare a forward revision with the default one instead of the newest forward revision (https://www.drupal.org/project/drupal/issues/2833049#comment-15868865)": "https://www.drupal.org/files/issues/2024-11-22/entity-revision_translation_changes-2833049-32.patch",
-                "Inconsistent database because of a bug in the Content Moderation module (https://www.drupal.org/project/drupal/issues/3088790#comment-15837881)": "https://www.drupal.org/files/issues/2024-10-30/content-moderation-unpublished-translation-3088790-37.patch"
-
+                "Inconsistent database because of a bug in the Content Moderation module (https://www.drupal.org/project/drupal/issues/3088790#comment-15837881)": "https://www.drupal.org/files/issues/2024-10-30/content-moderation-unpublished-translation-3088790-37.patch",
+                "Link to latest revision (https://www.drupal.org/i/2906455#comment-15996236)": "https://www.drupal.org/files/issues/2025-02-20/2906455-45.patch"
             },
             "drupal/message": {
                 "https://www.drupal.org/files/issues/2018-06-24/allow_token_contexts-3.patch": "https://www.drupal.org/files/issues/2018-06-24/allow_token_contexts-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c84316743d8f277b904fc2925f6f0760",
+    "content-hash": "ab3447227396acae074c3f50d06d6904",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",
@@ -6907,6 +6907,40 @@
                 "source": "https://git.drupalcode.org/project/mail_login",
                 "issues": "http://drupal.org/project/issues/mail_login",
                 "email": "mqanneh@gmail.com"
+            }
+        },
+        {
+            "name": "drupal/mailer_transport",
+            "version": "1.6.0-beta1",
+            "require": {
+                "drupal/core": "^10.3 || ^11",
+                "drupal/symfony_mailer": "^1"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "1.6.0-beta1",
+                    "datestamp": "1737896716",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "adamps",
+                    "homepage": "https://www.drupal.org/user/2650563"
+                }
+            ],
+            "description": "Placeholder to support upgrade to v2.x",
+            "homepage": "https://www.drupal.org/project/symfony_mailer",
+            "support": {
+                "source": "https://git.drupalcode.org/project/symfony_mailer"
             }
         },
         {

--- a/config/sync/language/en/views.view.group_content_ready_to_publish_revisions.yml
+++ b/config/sync/language/en/views.view.group_content_ready_to_publish_revisions.yml
@@ -7,6 +7,8 @@ display:
         edit_node:
           label: Operations
           text: Edit
+        link_to_latest_revision:
+          label: Service
       empty:
         area_text_custom:
           content: 'No services pending publishing'

--- a/config/sync/language/en/views.view.group_responsibility_services.yml
+++ b/config/sync/language/en/views.view.group_responsibility_services.yml
@@ -18,6 +18,8 @@ display:
           label: 'Responsible for service in the organisation'
         name:
           label: 'Responsible for service in municipality'
+        operations:
+          label: Operations
       filters:
         moderation_state_filter_exclude_archived:
           expose:

--- a/config/sync/language/en/views.view.service_rtb_publish_stats.yml
+++ b/config/sync/language/en/views.view.service_rtb_publish_stats.yml
@@ -4,3 +4,19 @@ display:
       empty:
         area_text_custom:
           content: 'Services waiting for publishing not found.'
+      fields:
+        title:
+          label: Service
+        link_to_latest_revision:
+          label: Service
+        changed:
+          label: Changed
+        moderation_state:
+          label: 'Published status'
+        time_since_last_state_change:
+          label: 'Days in current state'
+        gid:
+          label: Group
+        edit_node:
+          label: Operations
+          text: Edit

--- a/config/sync/views.view.group_content_ready_to_publish_revisions.yml
+++ b/config/sync/views.view.group_content_ready_to_publish_revisions.yml
@@ -101,14 +101,14 @@ display:
           id: title
           table: node_field_revision
           field: title
-          relationship: none
+          relationship: nid
           group_type: group
           admin_label: ''
           entity_type: node
           entity_field: title
           plugin_id: field
           label: Palvelu
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -151,7 +151,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -162,6 +162,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        link_to_latest_revision:
+          id: link_to_latest_revision
+          table: node_revision
+          field: link_to_latest_revision
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: link_to_latest_revision
+          label: Palvelu
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ title }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: ''
+          output_url_as_text: false
+          absolute: false
         gid:
           id: gid
           table: group_relationship_field_data

--- a/config/sync/views.view.service_rtb_publish_stats.yml
+++ b/config/sync/views.view.service_rtb_publish_stats.yml
@@ -692,14 +692,14 @@ display:
           id: title
           table: node_field_revision
           field: title
-          relationship: none
+          relationship: nid
           group_type: group
           admin_label: ''
           entity_type: node
           entity_field: title
           plugin_id: field
-          label: Title
-          exclude: false
+          label: Palvelu
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -731,7 +731,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -742,7 +742,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -753,6 +753,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        link_to_latest_revision:
+          id: link_to_latest_revision
+          table: node_revision
+          field: link_to_latest_revision
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: link_to_latest_revision
+          label: Palvelu
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ title }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: ''
+          output_url_as_text: false
+          absolute: false
         changed:
           id: changed
           table: node_field_revision
@@ -989,6 +1042,59 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        edit_node:
+          id: edit_node
+          table: node
+          field: edit_node
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link_edit
+          label: Toiminnot
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: muokkaa
+          output_url_as_text: false
+          absolute: false
       pager:
         type: none
         options:


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando composer install && lando drush deploy

**Testing instructions:**
- [ ] Make sure you have some previously published serives in the ready to publish state.
- [ ] Go to `/hallinta-ja-yllapito` page.
- [ ] Check that "Services awaiting publishing" has service names which point to the node's /latest url, if it exist. Check that there's a Edit operation.
- [ ] Go to `/group/GID` and check the same things for the views table.
- [ ] Go to `group/GID/group-responsibility-services` and check the same thing for the first table.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
