### PR TITLE
TP-1762 Fixed search language select warning, fixed no results showing when there's empty filters

### DIFF
--- a/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/SearchLanguageSelect.php
+++ b/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/SearchLanguageSelect.php
@@ -87,7 +87,7 @@ class SearchLanguageSelect extends RadioButtons implements ContainerFactoryPlugi
    * {@inheritdoc}
    */
   public function exposedFormAlter(array &$form, FormStateInterface $form_state) {
-    if ($this->view->search_language_filter === TRUE) {
+    if (!empty($this->view->search_language_filter) && $this->view->search_language_filter === TRUE) {
       return;
     }
 

--- a/public/modules/custom/views_exposed_embed/src/Plugin/Field/FieldFormatter/ViewsExposedEmbedFieldDefaultFormatter.php
+++ b/public/modules/custom/views_exposed_embed/src/Plugin/Field/FieldFormatter/ViewsExposedEmbedFieldDefaultFormatter.php
@@ -161,7 +161,8 @@ final class ViewsExposedEmbedFieldDefaultFormatter extends FormatterBase {
     $filters = $item->getValue();
     $filters = reset($filters);
     $filters = array_merge($filters, $this->getExposedFilterSelection());
-    return $filters;
+
+    return array_filter($filters);
   }
 
   /**


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush deploy

Since I couldn't reproduce this in local. This might need syncing of database from development environment

**Testing instructions:**
- [x] Login and re-index solr (this might need destroying and rebuilding lando env)
- [x] Go to /ukk/elamantilanne
- [x] Confirm service list shows values without the need for filtering

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
