### PR TITLE
TP-1787 Use node's internal path as front page

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /etusivu
+  front: /node/1
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: fi


### PR DESCRIPTION
Fixed showing the breadcrumb home link twice for non-default languages.

**Actions necessary for applying the changes:**
lando drush deploy

**Testing instructions:**
- [x] Go to front page and check the URL: the path is just `/`.
- [x] Go to the English translation front page: the path is just `/en`.
- [x] Go to the Favorites-page for all three languages.
- [x] The breadcrumb home link is not shown twice.
- [x] Go to some other page and check that the breadcrumb seems ok.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
