### PR TITLE
TP-1807 Added language logic for field_time_additional_info field display logic

### DIFF
--- a/public/modules/custom/hel_tpm_service_dates/hel_tpm_service_dates.module
+++ b/public/modules/custom/hel_tpm_service_dates/hel_tpm_service_dates.module
@@ -51,17 +51,25 @@ function hel_tpm_service_dates_field_widget_complete_form_alter(&$field_widget_c
  */
 function _hel_tpm_service_dates_service_date_selection(&$form, $form_state) {
   $controller = 'field_date_selection';
+  $storage = $form_state->getStorage();
+
   $parents = $form['#parents'];
   $parents[] = $controller;
   $user_input = $form_state->getUserInput();
 
   $selected_value = $form[$controller]['widget']['#default_value'];
 
-  if (!empty($user_input)) {
+  if (!empty($user_input) && $storage['entity_default_langcode'] === $storage['langcode']) {
     $selected_value = NestedArray::getValue($user_input, $parents);
   }
 
   $dependencies = [
+    'field_time_additional_info' => [
+      'date_not_available',
+      'start_and_end_date',
+      'service_continous',
+      'separate_dates',
+    ],
     'field_start_and_end_date' => [
       'start_and_end_date',
     ],


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush deploy


**Testing instructions:**
- [x] Login and create new service
- [x] Go to step 2 and add a a new time and place
- [x] Confirm field_time_additional_info doesn't show up on default
- [x] Select whatever date type and add content to field_time_additional_info
- [x] Save node
- [x] Add translation
- [x] Edit field_time_additional_info field
- [x] Save
- [x] Confirm translation values are saved

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
