### PR TITLE
TP-1850 Fixed age group filter reset when filtering with exposed form

### DIFF
--- a/public/modules/custom/views_exposed_embed/src/Plugin/views/display/ExposedEmbed.php
+++ b/public/modules/custom/views_exposed_embed/src/Plugin/views/display/ExposedEmbed.php
@@ -33,11 +33,6 @@ class ExposedEmbed extends Embed {
       $this->view->get_total_rows = TRUE;
     }
     $this->view->initHandlers();
-    if ($this->usesExposed()) {
-      /** @var \Drupal\views\Plugin\views\exposed_form\ExposedFormPluginInterface $exposed_form */
-      $exposed_form = $this->getPlugin('exposed_form');
-      $exposed_form->preExecute();
-    }
 
     $filters = $this->getDefaultFilters();
     if (!empty($filters)) {
@@ -45,9 +40,17 @@ class ExposedEmbed extends Embed {
         if (empty($this->view->filter[$field])) {
           continue;
         }
-        $this->view->exposed_data[$field] = $value;
         $this->view->filter[$field]->value = $value;
       }
+
+      $exposed_input = $this->view->getExposedInput();
+      $exposed_input = array_merge($exposed_input, $filters);
+      $this->view->setExposedInput($exposed_input);
+    }
+
+    if ($this->usesExposed()) {
+      $exposed_form = $this->getPlugin('exposed_form');
+      $exposed_form->preExecute();
     }
 
     foreach ($this->extenders as $extender) {


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush deploy

**Testing instructions:**
- [ ] Login and create basic page with service list with age groups filtered
- [ ] Use exposed municipality filter
- [ ] Confirm age groups filter doesn't reset after ajax

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
