### PR TITLE
TP-1857 Use comma as a decimal separator for prices

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.service_price.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.service_price.default.yml
@@ -36,7 +36,7 @@ content:
     label: hidden
     settings:
       thousand_separator: ''
-      decimal_separator: .
+      decimal_separator: ','
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush deploy

**Testing instructions:**
- [x] When editing services in Finnish, the price input has a comma as decimal separator.
- [x] When editing services in English, the price input has a dot as decimal separator. (Not changed this, as it's set by the browser.)
- [x] With all languagues, when viewing the service, the price has a comma as decimal separator.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
