### PR TITLE
TP-1879 Removed entity removal link from contact fields in translations

### DIFF
--- a/config/sync/core.entity_form_display.node.service.default.yml
+++ b/config/sync/core.entity_form_display.node.service.default.yml
@@ -617,17 +617,18 @@ content:
     region: content
     settings:
       form_mode: default
-      override_labels: false
       label_singular: ''
       label_plural: ''
-      allow_new: true
-      allow_existing: false
+      allow_new: '1'
       match_operator: CONTAINS
-      allow_duplicate: false
-      collapsible: false
-      collapsed: false
-      revision: false
       removed_reference: optional
+      prevent_translation_deletion: '1'
+      revision: 0
+      override_labels: 0
+      collapsible: 0
+      collapsed: 0
+      allow_existing: 0
+      allow_duplicate: 0
     third_party_settings:
       ief_popup:
         ief_popup_enabled: '1'
@@ -637,17 +638,18 @@ content:
     region: content
     settings:
       form_mode: default
-      override_labels: false
       label_singular: ''
       label_plural: ''
-      allow_new: true
-      allow_existing: false
+      allow_new: '1'
       match_operator: CONTAINS
-      allow_duplicate: false
-      collapsible: false
-      collapsed: false
-      revision: false
       removed_reference: optional
+      prevent_translation_deletion: '1'
+      revision: 0
+      override_labels: 0
+      collapsible: 0
+      collapsed: 0
+      allow_existing: 0
+      allow_duplicate: 0
     third_party_settings:
       ief_popup:
         ief_popup_enabled: '1'
@@ -775,6 +777,7 @@ content:
       collapsed: 0
       allow_existing: 0
       allow_duplicate: 0
+      prevent_translation_deletion: false
     third_party_settings:
       ief_popup:
         ief_popup_enabled: '1'
@@ -802,6 +805,7 @@ content:
       collapsed: 0
       allow_existing: 0
       allow_duplicate: 0
+      prevent_translation_deletion: false
     third_party_settings:
       ief_popup:
         ief_popup_enabled: '1'


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando composer install && lando drush deploy

**Testing instructions:**
- [x] Login
- [x] Edit default translation of service
- [x] Confirm there is contacts in internal and external contact fields
- [x] Confirm you can see removal button on each contact
- [x] Add or edit translation for service
- [x] Confirm there is no removal links in contact rows

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
