### PR TITLE
TP-1862 Fixed last state change calculation bug for views listing

### DIFF
--- a/public/modules/custom/hel_tpm_service_stats/hel_tpm_service_stats.module
+++ b/public/modules/custom/hel_tpm_service_stats/hel_tpm_service_stats.module
@@ -10,6 +10,13 @@ use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Database\Query\AlterableInterface;
 
 /**
+ * Implements hook_cron().
+ */
+function hel_tpm_service_stats_cron() {
+  \Drupal::service('hel_tpm_service_stats.cron')->cron();
+}
+
+/**
  * Implements hook_menu_local_tasks_alter().
  */
 function hel_tpm_service_stats_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {

--- a/public/modules/custom/hel_tpm_service_stats/hel_tpm_service_stats.services.yml
+++ b/public/modules/custom/hel_tpm_service_stats/hel_tpm_service_stats.services.yml
@@ -14,3 +14,12 @@ services:
     arguments: ['@hel_tpm_service_stats.revision_history']
     tags:
       - { name: event_subscriber }
+
+  hel_tpm_service_stats.cron:
+    class: Drupal\hel_tpm_service_stats\HelTpmServiceStatsCron
+    arguments: [
+      '@datetime.time',
+      '@entity_type.manager',
+      '@state',
+      '@queue'
+    ]

--- a/public/modules/custom/hel_tpm_service_stats/src/HelTpmServiceStatsCron.php
+++ b/public/modules/custom/hel_tpm_service_stats/src/HelTpmServiceStatsCron.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hel_tpm_service_stats;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\State\StateInterface;
+
+/**
+ * Handles the execution of cron jobs related to TPM service statistics.
+ *
+ * This class is responsible for determining the appropriate times for cron
+ * execution based on a predefined schedule, processing nodes
+ * related to services, and queuing tasks for further processing.
+ */
+final class HelTpmServiceStatsCron {
+
+  /**
+   * An array containing scheduled times in a 24-hour format.
+   *
+   * @var array|string[]
+   */
+  private array $schedule = ['01:00', '04:00'];
+
+  /**
+   * Entity storage interface.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  private EntityStorageInterface $storage;
+
+  /**
+   * Queue service.
+   *
+   * @var \Drupal\Core\Queue\QueueInterface
+   */
+  private $queue;
+
+  /**
+   * Constructs a HelTpmServiceStatsCron object.
+   */
+  public function __construct(
+    private readonly TimeInterface $datetimeTime,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly StateInterface $state,
+    private readonly QueueFactory $queueFactory,
+  ) {
+    $this->storage = $this->entityTypeManager->getStorage('node');
+    $this->queue = $this->queueFactory->get('hel_tpm_service_stats_days_since_last_state_change_updater');
+  }
+
+  /**
+   * Executes the cron logic for processing service-related nodes.
+   *
+   * The method checks whether the cron should run, processes nodes of the type
+   * "service" that have not been modified in the past 24 hours, and queues them
+   * for further processing in chunks. Finally, it updates the
+   * last cron run time in the state storage.
+   *
+   * @return void
+   *   void
+   */
+  public function cron(): void {
+    if (!$this->shouldRun()) {
+      return;
+    }
+    $request_time = $this->datetimeTime->getRequestTime();
+    $nids = $this->storage->getQuery()
+      ->condition('type', 'service')
+      ->condition('changed', $request_time - 86400, "<")
+      ->accessCheck(FALSE)
+      ->execute();
+    if (empty($nids)) {
+      return;
+    }
+
+    $chunks = array_chunk($nids, 10);
+    foreach ($chunks as $chunk) {
+      $this->queue->createItem($chunk);
+    }
+    $this->state->set('hel_tpm_service_stats.last_cron', $this->datetimeTime->getRequestTime());
+  }
+
+  /**
+   * Determines if a scheduled task should run now based on time and last run.
+   *
+   * The method evaluates the next scheduled execution time of the task by
+   * comparing it to the current time. If the current time has passed the next
+   * scheduled execution time, the method will return true indicating that the
+   * task should run.
+   *
+   * @return bool
+   *    True if the task should run, false otherwise.
+   */
+  public function shouldRun() {
+    $now = $this->datetimeTime->getRequestTime();
+
+    $timezone = new \DateTimeZone(date_default_timezone_get());
+
+    $current_time = DrupalDateTime::createFromFormat('U', $now)
+      ->setTimezone($timezone)
+      ->format('H');
+
+    $first_limit = explode(':', $this->schedule[0]);
+    $last_limit = explode(':', $this->schedule[1]);
+    if ($current_time < $first_limit[0] || $current_time > $last_limit[0]) {
+      return FALSE;
+    }
+
+    $timestamp_last = $this->state->get('hel_tpm_service_stats.last_cron') ?? 0;
+    $last = DrupalDateTime::createFromFormat('U', $timestamp_last)
+      ->setTimezone($timezone);
+    $next = clone $last;
+
+    $next->setTime(...$first_limit);
+    // If the cron ran on the same calendar day it should have, add one day.
+    if ($next->getTimestamp() <= $last->getTimestamp()) {
+      $next->modify('+1 day');
+    }
+
+    return $next->getTimestamp() <= $now;
+  }
+
+}

--- a/public/modules/custom/hel_tpm_service_stats/src/HelTpmServiceStatsCron.php
+++ b/public/modules/custom/hel_tpm_service_stats/src/HelTpmServiceStatsCron.php
@@ -95,7 +95,7 @@ final class HelTpmServiceStatsCron {
    * task should run.
    *
    * @return bool
-   *    True if the task should run, false otherwise.
+   *   True if the task should run, false otherwise.
    */
   public function shouldRun() {
     $now = $this->datetimeTime->getRequestTime();

--- a/public/modules/custom/hel_tpm_service_stats/src/Plugin/Field/ServiceRowGroupField.php
+++ b/public/modules/custom/hel_tpm_service_stats/src/Plugin/Field/ServiceRowGroupField.php
@@ -19,6 +19,9 @@ class ServiceRowGroupField extends EntityReferenceFieldItemList {
     $storage = \Drupal::entityTypeManager()->getStorage('node');
     $entity = $this->getEntity();
     $node_revision = $storage->loadRevision($entity->getPublishVid());
+    if (empty($node_revision)) {
+      return;
+    }
     $group_memberships = GroupMembership::loadByEntity($node_revision);
     foreach ($group_memberships as $membership) {
       $this->list[] = $this->createItem(0, $membership->getGroup());

--- a/public/modules/custom/hel_tpm_service_stats/src/Plugin/QueueWorker/DaysSinceLastStateChangeUpdater.php
+++ b/public/modules/custom/hel_tpm_service_stats/src/Plugin/QueueWorker/DaysSinceLastStateChangeUpdater.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hel_tpm_service_stats\Plugin\QueueWorker;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\hel_tpm_service_stats\RevisionHistoryService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines Days Since Last State Change Updater queue worker.
+ *
+ * @QueueWorker(
+ *   id = "hel_tpm_service_stats_days_since_last_state_change_updater",
+ *   title = @Translation("Days Since Last State Change Updater"),
+ *   cron = {"time" = 60},
+ * )
+ */
+final class DaysSinceLastStateChangeUpdater extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The storage handler interface instance.
+   */
+  private EntityStorageInterface $storage;
+
+  /**
+   * Constructs a new DaysSinceLastStateChangeUpdater instance.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly TimeInterface $datetimeTime,
+    private readonly RevisionHistoryService $helTpmServiceStatsRevisionHistory,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->storage = $this->entityTypeManager->getStorage('node');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('datetime.time'),
+      $container->get('hel_tpm_service_stats.revision_history'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data): void {
+    if (empty($data)) {
+      return;
+    }
+    foreach ($data as $nid) {
+      $node = $this->storage->load($nid);
+      if ($node->bundle() != 'service') {
+        continue;
+      }
+      $this->updateNodeLastStateChangeTimestamp($node);
+    }
+  }
+
+  /**
+   * Updates the last state change information of a node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity to update the last state change information for.
+   *
+   * @return void
+   *   This method does not return anything. It modifies the node entity
+   *   and persists the changes to the storage.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function updateNodeLastStateChangeTimestamp($node) {
+    $time_since_last_state_change = $this->helTpmServiceStatsRevisionHistory->getTimeSinceLastStateChange($node);
+
+    if (!$node->isDefaultRevision()) {
+      return;
+    }
+
+    $changed = $node->getChangedTime();
+    $revision_creation_time = $node->getRevisionCreationTime();
+
+    $node->set('field_days_since_last_state_chan', $time_since_last_state_change);
+    $node->setChangedTime($changed + 1);
+    $node->setRevisionCreationTime($revision_creation_time);
+    $node->setSyncing(TRUE);
+    $node->setNewRevision(FALSE);
+
+    $node->save();
+  }
+
+}

--- a/public/modules/custom/hel_tpm_service_stats/src/RevisionHistoryService.php
+++ b/public/modules/custom/hel_tpm_service_stats/src/RevisionHistoryService.php
@@ -179,8 +179,8 @@ final class RevisionHistoryService {
       ->execute()->fetchAll();
 
     foreach ($revisions as $revision) {
+      $last_revision = $revision;
       if ($revision->moderation_state === $state) {
-        $last_revision = $revision;
         continue;
       }
       break;

--- a/public/modules/custom/hel_tpm_service_stats/src/RevisionHistoryService.php
+++ b/public/modules/custom/hel_tpm_service_stats/src/RevisionHistoryService.php
@@ -179,8 +179,8 @@ final class RevisionHistoryService {
       ->execute()->fetchAll();
 
     foreach ($revisions as $revision) {
-      $last_revision = $revision;
       if ($revision->moderation_state === $state) {
+        $last_revision = $revision;
         continue;
       }
       break;

--- a/public/modules/custom/service_manual_workflow/service_manual_workflow.module
+++ b/public/modules/custom/service_manual_workflow/service_manual_workflow.module
@@ -214,6 +214,9 @@ function service_manual_workflow_entity_update(EntityInterface $entity) {
   if (empty($entity->original)) {
     return;
   }
+  if ($entity->getRevisionId() === $entity->original->getRevisionId()) {
+    return;
+  }
   $original_state = _service_manual_workflow_entity_previous_revision($entity);
   $state = $entity->moderation_state->value;
   $transition = sprintf('service_manual_workflow.%s.to.%s', $original_state, $state);


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando composer install && lando drush deploy

**Testing instructions:**
- [x] Login and find a service which hasn't been updated in a while but has states changed
- [x] lando drush cron
- [x] confirm hel_tpm_service_stats.cron **did not** execute
- [x] Edit public/modules/custom/hel_tpm_service_stats/src/HelTpmServiceStatsCron.php $schedule to 08:00 and 20:00
- [x] lando drush cron
- [x] Confirm hel_tpm_service_stats.cron **did** execute
- [x] lando drush cron
- [x] Confirm hel_tpm_service_stats.cron **did not** execute
- [x] Confirm from drupal10.node__field_days_since_last_state_chan that selected service has proper value
- [x] Confirm no reminder mails are sent during hel_tpm_service_stats.cron run


**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
