### PR TITLE
TP-1868 hide date selection title on date time element when there is …

### DIFF
--- a/public/themes/custom/palvelumanuaali/templates/paragraphs/paragraph--service-time-and-place.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/paragraphs/paragraph--service-time-and-place.html.twig
@@ -42,21 +42,22 @@
     paragraph.bundle|clean_class
   ]
 %}
-  <div{{ attributes.addClass(classes) }}>
-      {{content|without('field_separate_time','field_weekday_and_time','field_date_selection','field_start_and_end_date','field_date')}}
-      <div class='date-wrapper o--five d--flex'>
-        {% include "@atoms/images/icons/_icon.twig" with {
-          icon_base_class: 'icon',
-          icon_name: 'calendar-dark-blue',
-          icon_modifiers: ['small'],
-        } %}
+<div{{ attributes.addClass(classes) }}>
+  {{content|without('field_separate_time','field_weekday_and_time','field_date_selection','field_start_and_end_date','field_date')}}
+  {% if (content.field_date_selection['0']['#markup']) %}
+    <div class='date-wrapper o--five d--flex'>
+      {% include "@atoms/images/icons/_icon.twig" with {
+      icon_base_class: 'icon',
+      icon_name: 'calendar-dark-blue',
+      icon_modifiers: ['small'],
+      } %}
       <div class='text-wrapper'>
-      <div class='field__label'>{{ 'Weekday and time'|t }}</div>
+        <div class='field__label'>{{ 'Weekday and time'|t }}</div>
         {{content.field_date_selection}}
         {{content.field_start_and_end_date}}
         {{content.field_date}}
         {{content.field_weekday_and_time}}
       </div>
-      </div>
-
-  </div>
+    </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
…no selection made

**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

`Lando drush cr`

**Testing instructions:**
- [ ] Login and edit service 
- [ ] Go to second page of the service form
- [ ] Add 5 date and time elements
- [ ] Select one of each date time selection types (and fill required fields) and leave one date selection ("ajankohta, valitse yksi seuraavista) without selection
- [ ] Save and confirm that each of the saved elements with selections are visible
- [ ] Confirm there is no "weekday and time" + calendar icon on the element without date selection choice 


**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
