### PR TITLE
task/TP-1829_field_label_size

### DIFF
--- a/public/themes/custom/palvelumanuaali/templates/fields/field--node--field-service-benefits--service.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/fields/field--node--field-service-benefits--service.html.twig
@@ -40,7 +40,7 @@
 #}
 <div class="form-text-wrapper text-maxwidth">
 {% for item in items %}
-  <strong>{{"Benefits of participating in the service:"|t}}</strong>
+  <h3 class='h4'>{{"Benefits of participating in the service:"|t}}</h3>
   {{item.content}}
 {% endfor %}
 </div>

--- a/public/themes/custom/palvelumanuaali/templates/fields/field--node--field-service-requirements--service.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/fields/field--node--field-service-requirements--service.html.twig
@@ -40,7 +40,7 @@
 #}
 <div class="form-text-wrapper text-maxwidth">
 {% for item in items %}
-  <strong>{{"Conditions for participating in the service:"|t}}</strong>
+  <h3 class='h4'>{{"Conditions for participating in the service:"|t}}</h3>
   {{item.content}}
 {% endfor %}
 </div>


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

`lando drush cr`

Adjusts service description fields "benefits of participating the service" (Osallistumisen hyödyt) and  "Conditions for participating in the service" (Osallistumisen edellytykset) 
to be size h4


**Testing instructions:**
- [ ] Go to a service page with benefits of participating the service and Conditions for participating in the service fields filled or edit service and fill them
- [ ] Ensure that both of the labels are themed size h4 (have the class h4)

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
