### PR TITLE
TP-1923 Added default translation filter to services missing updaters view

### DIFF
--- a/config/sync/views.view.group_services_missing_updaters.yml
+++ b/config/sync/views.view.group_services_missing_updaters.yml
@@ -676,6 +676,46 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        default_langcode:
+          id: default_langcode
+          table: node_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: default_langcode
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/public/themes/custom/palvelumanuaali/components/05-pages/search/search-page-filters.js
+++ b/public/themes/custom/palvelumanuaali/components/05-pages/search/search-page-filters.js
@@ -100,9 +100,24 @@
           localStorage.setItem('searchFiltersIsCollapsed', isCollapsed);
           showHideAdditionalFilters(filterWrapper, isCollapsed);
           setAriaExpanded(isCollapsed);
+          setTogglerLabel(isCollapsed);
         });
       }
 
+      /**
+       * Updates the label text of a toggler based on its collapsed state.
+       *
+       * @param {string} isCollapsed
+       *    A string that determines the state of the toggler.
+       *    Should be "true" for collapsed or any other value for expanded.
+       * @return {void}
+       *    This function does not return a value.
+       */
+      function setTogglerLabel(isCollapsed) {
+        let label = isCollapsed === "true" ? Drupal.t("Show more") : Drupal.t("Show less");
+        let toggler = ".collapse-toggler";
+        $(toggler).text(label);
+      }
       /**
        * Set aria-expanded value for collapse-toggler.
        *
@@ -110,10 +125,8 @@
        * @param isCollapsed
        */
       function setAriaExpanded(isCollapsed) {
-        let expanded = "true";
-        if (isCollapsed === "true")
-          expanded = "false"
-        $(".collapse-toggler").attr('aria-expanded', expanded);
+        let toggler = ".collapse-toggler";
+        $(toggler).attr('aria-expanded', isCollapsed);
       }
 
       /**

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1650,3 +1650,9 @@ msgstr "Loppuu klo"
 
 msgid "Service price is required"
 msgstr "Palvelun hintatieto on pakollinen"
+
+msgid "Show more"
+msgstr "Näytä lisää"
+
+msgid "Show less"
+msgstr "Näytä vähemmän"

--- a/translations/sv-interface-translations.po
+++ b/translations/sv-interface-translations.po
@@ -997,3 +997,9 @@ msgstr "Börjar kl"
 
 msgid "End Time"
 msgstr "Slutar kl"
+
+msgid "Show more"
+msgstr "Visa mer"
+
+msgid "Show less"
+msgstr "Visa färre"


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*
lando drush deploy


**Testing instructions:**
- [x] Login
- [x] Go to group and archive one of the services with translations
- [x] Change the service to draft
- [x] Go to "Puuttuvat vastuupäivittäjät"
- [x] Confirm translations does not show on list
- [x] Publish service
- [x] Block service responsible updater from users-page
- [x] drush cr
- [x] Confirm service appears in groups "Puuttuvat vastuupäivittäjä"

TP-1788
- [x] lando drush locale:import sv ../translations/sv-interface-translations.po
- [x] lando drush locale:import fi ../translations/fi-interface-translations.po 
- [x] Go to search page
- [x] Click filter toggler label changes when clicked and label is translated in swedish/english/finnish

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
