### PR TITLE
TP-1859 Hide translatability clues from weekday titles

### DIFF
--- a/public/modules/custom/hel_tpm_service_dates/src/Plugin/Field/FieldWidget/ServiceTimeAndPlaceWidgetWidget.php
+++ b/public/modules/custom/hel_tpm_service_dates/src/Plugin/Field/FieldWidget/ServiceTimeAndPlaceWidgetWidget.php
@@ -46,6 +46,7 @@ class ServiceTimeAndPlaceWidgetWidget extends ParagraphsClassicAsymmetricWidget 
     $element['top']['links']['remove_button']['#paragraphs_mode'] = 'removed';
 
     $this->createFieldStatesRules($element);
+    $element['#after_build'][] = [get_class($this), 'removeTranslatabilityClue'];
 
     return $element;
   }
@@ -85,6 +86,48 @@ class ServiceTimeAndPlaceWidgetWidget extends ParagraphsClassicAsymmetricWidget 
     $this->clearUnselectedDateFields($element, $form_state);
     $this->validateRequiredDependencyFields($element, $form_state);
     parent::elementValidate($element, $form_state, $form);
+  }
+
+  /**
+   * Removes "(all languages)" suffix from the weekday checkbox titles.
+   *
+   * The title is replaced with a value from '#original_title' item.
+   *
+   * @param array $element
+   *   The form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The form element.
+   */
+  public static function removeTranslatabilityClue(array $element, FormStateInterface $form_state): array {
+    if (empty($element['subform']['field_weekday_and_time']) || empty($element['subform']['field_weekday_and_time']['widget'])) {
+      return $element;
+    }
+
+    $weekdayAndTimeValues = $element['subform']['field_weekday_and_time']['widget'][0]['value'];
+    $replacedWithOriginal = FALSE;
+
+    foreach ($weekdayAndTimeValues as $key => $value) {
+      // Unlike other keys, weekday keys are not prefixed with a hashtag symbol.
+      if (str_starts_with($key, '#')) {
+        continue;
+      }
+      if (!isset($value[0]['selector']['#title']) || !isset($value[0]['selector']['#original_title'])) {
+        continue;
+      }
+      if ($value[0]['selector']['#title'] !== $value[0]['selector']['#original_title']) {
+        $weekdayAndTimeValues[$key][0]['selector']['#title'] = $value[0]['selector']['#original_title'];
+        $replacedWithOriginal = TRUE;
+      }
+    }
+
+    if ($replacedWithOriginal) {
+      $element['subform']['field_weekday_and_time']['widget'][0]['value'] = $weekdayAndTimeValues;
+    }
+
+    return $element;
   }
 
   /**

--- a/public/modules/custom/hel_tpm_service_dates/src/Plugin/Field/FieldWidget/WeekdayAndTimeFieldWidget.php
+++ b/public/modules/custom/hel_tpm_service_dates/src/Plugin/Field/FieldWidget/WeekdayAndTimeFieldWidget.php
@@ -205,6 +205,8 @@ final class WeekdayAndTimeFieldWidget extends WidgetBase {
         '#type' => 'checkbox',
         // phpcs:ignore
         '#title' => $this->t($label),
+        // phpcs:ignore
+        '#original_title' => $this->t($label),
         '#attributes' => [
           'data-selector' => $selector,
           'autocomplete' => 'off',


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush  deploy

**Testing instructions:**
- [x] Edit existing service translation.
- [x] Ensure weekday and time element's weekday titles (mon–sun) are show correctly.
- [x] Create a new service translation.
- [x] Ensure weekday and time element's weekday titles (mon–sun) are show correctly.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
