### PR TITLE
Added null check when fetching latesttranslationaffected revision.

### DIFF
--- a/public/modules/custom/hel_tpm_editorial/src/Plugin/views/field/ServiceHasUnpublishedChanges.php
+++ b/public/modules/custom/hel_tpm_editorial/src/Plugin/views/field/ServiceHasUnpublishedChanges.php
@@ -103,15 +103,17 @@ class ServiceHasUnpublishedChanges extends FieldPluginBase {
 
     if (!$entity->isLatestTranslationAffectedRevision()) {
       $latest_translation_affected = $this->getLatestTranslationAffectedRevision($entity);
-      if ($entity->get('moderation_state')->value !== $latest_translation_affected->get('moderation_state')->value) {
-        $moderation_state = $this->getLatestRevisionModerationState($entity);
-        return [
-          '#theme' => 'service_has_changes_field',
-          '#link' => $this->linkGenerator()->generate('Unpublished changes', $this->latestRevisionUrl($entity)),
-          '#state' => $moderation_state,
-        ];
+      if (!empty($latest_translation_affected)) {
+        if ($entity->get('moderation_state')->value !== $latest_translation_affected->get('moderation_state')->value) {
+          $moderation_state = $this->getLatestRevisionModerationState($entity);
+          return [
+            '#theme' => 'service_has_changes_field',
+            '#link' => $this->linkGenerator()
+              ->generate('Unpublished changes', $this->latestRevisionUrl($entity)),
+            '#state' => $moderation_state,
+          ];
+        }
       }
-
     }
     return ['#markup' => $this->t('Up to date')];
   }


### PR DESCRIPTION
**Actions necessary for applying the changes:** *(for example composer install; drush updb; drush cim)*

lando drush cr

**Testing instructions:**
- [x] Login and create a new service and add a translation (don't save either more than once)
- [x] Go to /hallinta-ja-yllapito
- [x] Confirm page doesn't crash
- [x] Go to database
- [x] Open node_field_revision table
- [x] Edit translations revision revision_translation_affected value to 0
- [x] Go to /hallinta-ja-yllapito
- [x] Confirm page doesn't crash


**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
- [ ] I have moved the ticket to the approval lane, added testing instructions and assigned it to the product owner.
