### PR TITLE
TP-1950 Fix service page date and time order

### DIFF
--- a/public/themes/custom/palvelumanuaali/templates/paragraphs/paragraph--service-time-and-place.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/paragraphs/paragraph--service-time-and-place.html.twig
@@ -43,12 +43,12 @@
   ]
 %}
 {% set date_fields = [
-    'field_separate_time',
-    'field_weekday_and_time',
     'field_date_selection',
     'field_start_and_end_date',
     'field_date',
-    'field_multiple_dates'
+    'field_multiple_dates',
+    'field_separate_time',
+    'field_weekday_and_time'
   ]
 %}
 <div{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
**Actions necessary for applying the changes:**
lando drush cr

**Testing instructions:**
- [ ] Make sure you have a service with different date and time selections.
- [ ] Make sure there's a start and end date with weekdays and times.
- [ ] View the service: the date should be above the corresponding weekday and time info.

**Review checklist:**
- [ ] The code conforms to Drupal coding standards
- [ ] I have reviewed the code for security and quality issues
- [ ] I have tested the code with the proper **user** roles
