### PR TITLE
TP-2152 add missing public files field to field description tooltip

### DIFF
--- a/config/sync/field_description_tooltip.settings.yml
+++ b/config/sync/field_description_tooltip.settings.yml
@@ -164,6 +164,7 @@ at_2: center
 'node:service:field_other_services': 1
 'node:service:field_poma_applicable': 1
 'node:service:field_poma_applicable_descriptio': 1
+'node:service:field_public_files': 1
 'node:service:field_related_archive': 1
 'node:service:field_responsible_municipality': 1
 'node:service:field_responsible_updatee': 1


### PR DESCRIPTION
## Actions for applying the changes locally
`lando drush deploy`

Fixes missing tooltip from new service form page 3 (public files field)

## Testing instructions
- [x] Login and create new service.
- [x] Go to page 3 and scroll down to the public files field
- [x] Tooltip is rendered properly for the field

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
