### PR TITLE
Bug/tp 2146 service not expired

### DIFF
--- a/config/sync/system.action.reset_update_reminder.yml
+++ b/config/sync/system.action.reset_update_reminder.yml
@@ -1,0 +1,11 @@
+uuid: 3a97c9b4-7a26-4963-9e99-1748e131be14
+langcode: fi
+status: true
+dependencies:
+  module:
+    - hel_tpm_update_reminder
+id: reset_update_reminder
+label: 'Reset Update Reminder'
+type: node
+plugin: hel_tpm_update_reminder_reset_update_reminder
+configuration: {  }

--- a/config/sync/user.role.admin.yml
+++ b/config/sync/user.role.admin.yml
@@ -39,6 +39,7 @@ dependencies:
     - hel_tpm_contact_info
     - hel_tpm_general
     - hel_tpm_group
+    - hel_tpm_update_reminder
     - locale
     - media
     - node
@@ -251,6 +252,7 @@ permissions:
   - 'edit terms in service_set'
   - 'flag lists'
   - 'grant node permissions'
+  - 'reset update reminder'
   - 'revert all revisions'
   - 'submit translation jobs'
   - 'translate editable entities'

--- a/public/modules/custom/hel_tpm_update_reminder/config/install/system.action.reset_update_reminder.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/config/install/system.action.reset_update_reminder.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - hel_tpm_update_reminder
+id: reset_update_reminder
+label: 'Reset Update Reminder'
+type: node
+plugin: hel_tpm_update_reminder_reset_update_reminder
+configuration: {  }

--- a/public/modules/custom/hel_tpm_update_reminder/config/schema/hel_tpm_update_reminder.schema.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/config/schema/hel_tpm_update_reminder.schema.yml
@@ -1,0 +1,3 @@
+action.configuration.hel_tpm_update_reminder_reset_update_reminder:
+  type: action_configuration_default
+  label: 'Reset Update Reminder'

--- a/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.permissions.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/hel_tpm_update_reminder.permissions.yml
@@ -1,0 +1,2 @@
+reset update reminder:
+  title: 'Reset Update Reminders'

--- a/public/modules/custom/hel_tpm_update_reminder/src/Plugin/Action/ResetUpdateReminderAction.php
+++ b/public/modules/custom/hel_tpm_update_reminder/src/Plugin/Action/ResetUpdateReminderAction.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hel_tpm_update_reminder\Plugin\Action;
+
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Logger\LoggerChannelTrait;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hel_tpm_update_reminder\UpdateReminderUtility;
+use Drupal\views_bulk_operations\Action\ViewsBulkOperationsActionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a Reset Update Reminder action.
+ */
+#[Action(
+  id: 'hel_tpm_update_reminder_reset_update_reminder',
+  label: new TranslatableMarkup('Reset Update Reminder'),
+  type: 'node'
+)]
+final class ResetUpdateReminderAction extends ViewsBulkOperationsActionBase implements ContainerFactoryPluginInterface {
+
+  use LoggerChannelTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    private readonly StateInterface $state,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('state')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($entity, ?AccountInterface $account = NULL, $return_as_object = FALSE): AccessResultInterface|bool {
+    return $account->hasPermission('reset update reminder');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(?ContentEntityInterface $entity = NULL): void {
+    UpdateReminderUtility::clearMessagesSent((int) $entity->id());
+    $this->getLogger('hel_tpm_update_reminder_reset_update_reminder')->notice('Reset update reminders for @node', ['@node' => $entity->label()]);
+  }
+
+}

--- a/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/system.action.reset_update_reminder.yml
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/modules/hel_tpm_update_reminder_test/config/install/system.action.reset_update_reminder.yml
@@ -1,0 +1,10 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - hel_tpm_update_reminder
+id: reset_update_reminder
+label: 'Reset Update Reminder'
+type: node
+plugin: hel_tpm_update_reminder_reset_update_reminder
+configuration: {  }

--- a/public/modules/custom/hel_tpm_update_reminder/tests/src/Kernel/ResetUpdateReminderActionTest.php
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/src/Kernel/ResetUpdateReminderActionTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Drupal\Tests\hel_tpm_update_reminder\Kernel;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Database\Database;
+use Drupal\Core\Test\AssertMailTrait;
+use Drupal\group\Entity\Group;
+use Drupal\hel_tpm_update_reminder\UpdateReminderUtility;
+use Drupal\Tests\group\Kernel\GroupKernelTestBase;
+use Drupal\Tests\hel_tpm_update_reminder\ServiceUpdateReminderTrait;
+use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Provides test coverage for the reset update reminder action.
+ *
+ * This test class ensures the proper functionality of reminder messages
+ * and transition states of services, including handling outdated status
+ * and resetting reminders.
+ */
+final class ResetUpdateReminderActionTest extends GroupKernelTestBase {
+
+  use UserCreationTrait;
+  use AssertMailTrait;
+  use ContentTypeCreationTrait;
+  use ServiceUpdateReminderTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'content_moderation',
+    'content_translation',
+    'language',
+    'workflows',
+    'node',
+    'flexible_permissions',
+    'message',
+    'message_notify',
+    'message_notify_test',
+    'service_manual_workflow',
+    'group',
+    'ggroup',
+    'gnode',
+    'gcontent_moderation',
+    'hel_tpm_update_reminder',
+    'hel_tpm_update_reminder_test',
+    'hel_tpm_general',
+    'hel_tpm_mail_tools',
+    'purge',
+    'dblog',
+    'system',
+  ];
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The cron service.
+   *
+   * @var \Drupal\Core\Cron
+   */
+  protected $cron;
+
+  /**
+   * The queue container.
+   *
+   * @var \Drupal\Core\Queue\DatabaseQueue
+   */
+  protected $queue;
+
+  /**
+   * The group entity.
+   *
+   * @var \Drupal\group\Entity\Group
+   */
+  private Group $group;
+
+  /**
+   * Represents the second group of entities or configurations.
+   *
+   * @var mixed
+   */
+  private Group $group2;
+
+  /**
+   * The action to reset the update reminder.
+   *
+   * @var \Drupal\update\Plugin\Action\ResetUpdateReminder
+   */
+  private ?EntityInterface $resetUpdateReminderAction;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('content_moderation_state');
+    $this->installEntitySchema('message');
+    $this->installEntitySchema('group');
+    $this->installEntitySchema('group_content');
+    $this->installEntitySchema('action');
+    $this->installSchema('node', ['node_access']);
+    $this->installSchema('dblog', ['watchdog']);
+    $this->installConfig(['field', 'node', 'system']);
+    $this->installConfig([
+      'content_moderation',
+      'hel_tpm_update_reminder_test',
+    ]);
+
+    $this->cron = \Drupal::service('cron');
+    $this->connection = Database::getConnection();
+    $this->queue = $this->container->get('queue')->get('hel_tpm_update_reminder_service');
+
+    $group_type = $this->createGroupType();
+    $storage = $this->entityTypeManager->getStorage('group_content_type');
+    $storage->createFromPlugin($group_type, 'group_node:service', [])->save();
+
+    $this->group = $this->createGroup(['type' => $group_type->id()]);
+    $this->group2 = $this->createGroup(['type' => $group_type->id()]);
+
+    $this->resetUpdateReminderAction = $this->entityTypeManager->getStorage('action')
+      ->load('reset_update_reminder');
+  }
+
+  /**
+   * Tests the reset update reminder action functionality.
+   *
+   * This method verifies the behavior of the reset update reminder action by
+   * simulating various scenarios such as sending reminders at different stages,
+   * marking a service as outdated, and resetting reminder counts.
+   *
+   * @return void
+   *   This method does not return a value, but ensures that the reminder
+   *   functionality works as intended through assertions.
+   */
+  public function testResetUpdateReminderAction(): void {
+    // Test with service not saved for long time, add a translation, and ensure
+    // the first reminder is sent.
+    $service = $this->createServiceWithTransition('ready_to_publish', 'published', UpdateReminderUtility::LIMIT_1 + 1, TRUE);
+
+    $this->cron->run();
+
+    $this->assertEquals(1, UpdateReminderUtility::getMessagesSent($service->id()));
+
+    // Ensure the second reminder is sent after enough time is passed.
+    $this->setRemindedTimestampToValue((int) $service->id(), UpdateReminderUtility::LIMIT_2 + 1);
+    $this->cronRunHelper();
+    $this->assertEquals(2, UpdateReminderUtility::getMessagesSent($service->id()));
+
+    // Ensure the service is outdated and the related message is sent after
+    // enough time is passed.
+    $this->setRemindedTimestampToValue((int) $service->id(), UpdateReminderUtility::LIMIT_3 + 1);
+    $this->cronRunHelper();
+    $this->assertEquals(3, UpdateReminderUtility::getMessagesSent($service->id()));
+    $service = $this->reloadEntity($service);
+    $this->assertEquals('outdated', $service->get('moderation_state')->value);
+
+    // Update the service back to published state.
+    $this->updateService((int) $service->id(), [
+      'moderation_state' => 'published',
+    ], UpdateReminderUtility::LIMIT_1);
+    $service = $this->reloadEntity($service);
+    $this->assertEquals('published', $service->get('moderation_state')->value);
+
+    $this->resetUpdateReminderAction->execute([$service]);
+    $this->assertEquals(0, UpdateReminderUtility::getMessagesSent($service->id()));
+
+    $this->setRemindedTimestampToValue((int) $service->id(), UpdateReminderUtility::LIMIT_1 + 1);
+    $this->cronRunHelper();
+
+    $this->assertEquals(1, UpdateReminderUtility::getMessagesSent($service->id()));
+  }
+
+}

--- a/public/modules/custom/hel_tpm_update_reminder/tests/src/Kernel/ServiceUpdateReminderTest.php
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/src/Kernel/ServiceUpdateReminderTest.php
@@ -6,17 +6,15 @@ namespace Drupal\Tests\hel_tpm_update_reminder\Kernel;
 
 use Drupal\Core\Database\Database;
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Test\AssertMailTrait;
 use Drupal\group\Entity\Group;
-use Drupal\group\Entity\GroupInterface;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\group\Kernel\GroupKernelTestBase;
+use Drupal\Tests\hel_tpm_update_reminder\ServiceUpdateReminderTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\hel_tpm_mail_tools\Utility\PreventMailUtility;
 use Drupal\hel_tpm_update_reminder\UpdateReminderUtility;
-use Drupal\node\Entity\Node;
 
 /**
  * Service update reminder tests.
@@ -28,6 +26,7 @@ final class ServiceUpdateReminderTest extends GroupKernelTestBase {
   use UserCreationTrait;
   use AssertMailTrait;
   use ContentTypeCreationTrait;
+  use ServiceUpdateReminderTrait;
 
   /**
    * {@inheritdoc}
@@ -714,200 +713,6 @@ final class ServiceUpdateReminderTest extends GroupKernelTestBase {
     ], 1);
     $remind_service = $update_reminder_service->getServiceIdsToRemind();
     $this->assertCount(0, $remind_service);
-  }
-
-  /**
-   * Updates last run state.
-   *
-   * @param int $hours
-   *   Defines how many hours ago was the last run.
-   *
-   * @return void
-   *   -
-   */
-  protected function updateLastRunTimestamp(int $hours = UpdateReminderUtility::RUN_LIMIT_HOURS): void {
-    $timestamp = strtotime('-' . $hours . ' hours', \Drupal::time()->getRequestTime());
-    \Drupal::state()->set(UpdateReminderUtility::LAST_RUN_KEY, $timestamp);
-  }
-
-  /**
-   * Helper function to always run service update reminder with cron.
-   *
-   * @return void
-   *   -
-   */
-  protected function cronRunHelper(): void {
-    \Drupal::state()->delete(UpdateReminderUtility::LAST_RUN_KEY);
-    $this->cron->run();
-  }
-
-  /**
-   * Set node content as reminded with past timestamp.
-   *
-   * @param int $nid
-   *   The node id.
-   * @param int $days
-   *   Defines how many days ago the node was reminded.
-   *
-   * @return void
-   *   -
-   */
-  protected function setRemindedTimestampToValue(int $nid, int $days): void {
-    $timestamp = strtotime('-' . $days . ' days', \Drupal::time()->getRequestTime());
-    \Drupal::state()->set(UpdateReminderUtility::REMINDED_BASE_KEY . $nid, $timestamp);
-  }
-
-  /**
-   * Creates service with randomized title.
-   *
-   * @param array $values
-   *   Array of values for service node.
-   * @param \Drupal\group\Entity\GroupInterface $group
-   *   Group interface.
-   *
-   * @return \Drupal\Core\Entity\EntityInterface
-   *   Node entity interface.
-   *
-   * @throws \Drupal\Core\Entity\EntityStorageException
-   */
-  protected function createService(array $values, GroupInterface $group): EntityInterface {
-    $values += [
-      'type' => 'service',
-      'title' => $this->randomMachineName(8),
-    ];
-    $node = Node::create($values);
-    $node->save();
-    $group->addRelationship($node, 'group_node:service');
-
-    // Ensure revisions have proper changed date after group relationship.
-    if (!empty($values['changed'])) {
-      $this->ensureChangedDate($node, $values['changed']);
-    }
-    return $this->reloadEntity($node);
-  }
-
-  /**
-   * Updates service moderation state and sets changed and checked timestamps.
-   *
-   * @param int $nid
-   *   The node id.
-   * @param array $values
-   *   Array of values for service node.
-   * @param int $days
-   *   Defines how many days ago the node was changed and saved.
-   *
-   * @return \Drupal\Core\Entity\EntityInterface
-   *   Node entity interface.
-   *
-   * @throws \Drupal\Core\Entity\EntityStorageException
-   */
-  protected function updateService(int $nid, array $values, int $days): EntityInterface {
-    $node = Node::load($nid);
-    $changed = strtotime('-' . $days . ' days', \Drupal::time()->getRequestTime());
-
-    if (!$node->isLatestRevision()) {
-      $vid = \Drupal::entityTypeManager()
-        ->getStorage('node')
-        ->getLatestRevisionId($nid);
-      $node = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($vid);
-    }
-    foreach ($values as $key => $value) {
-      $node->set($key, $value);
-    }
-
-    $node->setChangedTime($changed);
-    $node->setRevisionCreationTime($changed);
-    $node->setRevisionUserId(\Drupal::CurrentUser()->id());
-    $node->save();
-    return $this->reloadEntity($node);
-  }
-
-  /**
-   * Creates and updates a service with given moderation state transition.
-   *
-   * @param string $fromState
-   *   The initial moderation state.
-   * @param string $toState
-   *   The updated moderation state.
-   * @param int $days
-   *   Defines how many days ago the service was changed and saved.
-   * @param bool $addUser
-   *   Defines whether service provider user is added.
-   *
-   * @return \Drupal\Core\Entity\EntityInterface
-   *   The created service.
-   *
-   * @throws \Drupal\Core\Entity\EntityStorageException
-   */
-  protected function createServiceWithTransition(string $fromState, string $toState, int $days, bool $addUser = FALSE): EntityInterface {
-    $user = NULL;
-    if ($addUser) {
-      $user = $this->createUser([], NULL, FALSE, [
-        'mail' => $this->randomMachineName(8) . '@tpm.test',
-        'status' => 1,
-      ]);
-      $this->group->addMember($user);
-    }
-    // Make sure newly created services are behind new ones.
-    $changed = strtotime('-' . $days . ' days 1 hours', \Drupal::time()->getRequestTime());
-    $service = $this->createService([
-      'field_service_provider_updatee' => $user,
-      'moderation_state' => $fromState,
-      'created' => $changed,
-      'changed' => $changed,
-      'uid' => $addUser ? $user->id() : 0,
-    ], $this->group);
-    $this->group->addRelationship($service, 'group_node:service');
-
-    return $this->updateService((int) $service->id(), [
-      'moderation_state' => $toState,
-    ], $days);
-  }
-
-  /**
-   * Ensures the service's changed date is updated to the provided timestamp.
-   *
-   * @param \Drupal\node\NodeInterface $service
-   *   The service node whose changed date needs to be updated.
-   * @param int $timestamp
-   *   The timestamp to set for the changed date.
-   *
-   * @return void
-   *   -
-   */
-  protected function ensureChangedDate($service, $timestamp) {
-    $tables = ['node_revision' => 'revision_timestamp', 'node_field_revision' => 'changed'];
-    foreach ($tables as $table => $column) {
-      \Drupal::database()->update($table)
-        ->fields([$column => $timestamp])
-        ->condition('nid', $service->id())
-        ->execute();
-    }
-  }
-
-  /**
-   * Gets an array containing all update remainder mails.
-   *
-   * @return array
-   *   An array containing captured email messages.
-   */
-  protected function getReminderMails(): array {
-    return array_merge(
-      $this->getMails(['id' => 'message_notify_hel_tpm_update_reminder_service']),
-      $this->getMails(['id' => 'message_notify_hel_tpm_update_reminder_service2'])
-    );
-  }
-
-  /**
-   * Gets an array containing all service outdated mails.
-   *
-   * @return array
-   *   An array containing captured email messages.
-   */
-  protected function getOutdatedMails(): array {
-    return $this->getMails([
-      'id' => 'message_notify_hel_tpm_update_reminder_outdated',
-    ]);
   }
 
 }

--- a/public/modules/custom/hel_tpm_update_reminder/tests/src/ServiceUpdateReminderTrait.php
+++ b/public/modules/custom/hel_tpm_update_reminder/tests/src/ServiceUpdateReminderTrait.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hel_tpm_update_reminder;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\group\Entity\GroupInterface;
+use Drupal\hel_tpm_update_reminder\UpdateReminderUtility;
+use Drupal\node\Entity\Node;
+
+/**
+ * Provides utility methods for handling service update reminders.
+ */
+trait ServiceUpdateReminderTrait {
+
+  /**
+   * Updates last run state.
+   *
+   * @param int $hours
+   *   Defines how many hours ago was the last run.
+   *
+   * @return void
+   *   -
+   */
+  protected function updateLastRunTimestamp(int $hours = UpdateReminderUtility::RUN_LIMIT_HOURS): void {
+    $timestamp = strtotime('-' . $hours . ' hours', \Drupal::time()->getRequestTime());
+    \Drupal::state()->set(UpdateReminderUtility::LAST_RUN_KEY, $timestamp);
+  }
+
+  /**
+   * Helper function to always run service update reminder with cron.
+   *
+   * @return void
+   *   -
+   */
+  protected function cronRunHelper(): void {
+    \Drupal::state()->delete(UpdateReminderUtility::LAST_RUN_KEY);
+    $this->cron->run();
+  }
+
+  /**
+   * Set node content as reminded with past timestamp.
+   *
+   * @param int $nid
+   *   The node id.
+   * @param int $days
+   *   Defines how many days ago the node was reminded.
+   *
+   * @return void
+   *   -
+   */
+  protected function setRemindedTimestampToValue(int $nid, int $days): void {
+    $timestamp = strtotime('-' . $days . ' days', \Drupal::time()->getRequestTime());
+    \Drupal::state()->set(UpdateReminderUtility::REMINDED_BASE_KEY . $nid, $timestamp);
+  }
+
+  /**
+   * Creates service with randomized title.
+   *
+   * @param array $values
+   *   Array of values for service node.
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   Group interface.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   Node entity interface.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createService(array $values, GroupInterface $group): EntityInterface {
+    $values += [
+      'type' => 'service',
+      'title' => $this->randomMachineName(8),
+    ];
+    $node = Node::create($values);
+    $node->save();
+    $group->addRelationship($node, 'group_node:service');
+
+    // Ensure revisions have proper changed date after group relationship.
+    if (!empty($values['changed'])) {
+      $this->ensureChangedDate($node, $values['changed']);
+    }
+    return $this->reloadEntity($node);
+  }
+
+  /**
+   * Updates service moderation state and sets changed and checked timestamps.
+   *
+   * @param int $nid
+   *   The node id.
+   * @param array $values
+   *   Array of values for service node.
+   * @param int $days
+   *   Defines how many days ago the node was changed and saved.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   Node entity interface.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function updateService(int $nid, array $values, int $days): EntityInterface {
+    $node = Node::load($nid);
+    $changed = strtotime('-' . $days . ' days', \Drupal::time()->getRequestTime());
+
+    if (!$node->isLatestRevision()) {
+      $vid = \Drupal::entityTypeManager()
+        ->getStorage('node')
+        ->getLatestRevisionId($nid);
+      $node = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($vid);
+    }
+    foreach ($values as $key => $value) {
+      $node->set($key, $value);
+    }
+
+    $node->setChangedTime($changed);
+    $node->setRevisionCreationTime($changed);
+    $node->setRevisionUserId(\Drupal::CurrentUser()->id());
+    $node->save();
+    return $this->reloadEntity($node);
+  }
+
+  /**
+   * Creates and updates a service with given moderation state transition.
+   *
+   * @param string $fromState
+   *   The initial moderation state.
+   * @param string $toState
+   *   The updated moderation state.
+   * @param int $days
+   *   Defines how many days ago the service was changed and saved.
+   * @param bool $addUser
+   *   Defines whether service provider user is added.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The created service.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createServiceWithTransition(string $fromState, string $toState, int $days, bool $addUser = FALSE): EntityInterface {
+    $user = NULL;
+    if ($addUser) {
+      $user = $this->createUser([], NULL, FALSE, [
+        'mail' => $this->randomMachineName(8) . '@tpm.test',
+        'status' => 1,
+      ]);
+      $this->group->addMember($user);
+    }
+    // Make sure newly created services are behind new ones.
+    $changed = strtotime('-' . $days . ' days 1 hours', \Drupal::time()->getRequestTime());
+    $service = $this->createService([
+      'field_service_provider_updatee' => $user,
+      'moderation_state' => $fromState,
+      'created' => $changed,
+      'changed' => $changed,
+      'uid' => $addUser ? $user->id() : 0,
+    ], $this->group);
+    $this->group->addRelationship($service, 'group_node:service');
+
+    return $this->updateService((int) $service->id(), [
+      'moderation_state' => $toState,
+    ], $days);
+  }
+
+  /**
+   * Ensures the service's changed date is updated to the provided timestamp.
+   *
+   * @param \Drupal\node\NodeInterface $service
+   *   The service node whose changed date needs to be updated.
+   * @param int $timestamp
+   *   The timestamp to set for the changed date.
+   *
+   * @return void
+   *   -
+   */
+  protected function ensureChangedDate($service, $timestamp) {
+    $tables = ['node_revision' => 'revision_timestamp', 'node_field_revision' => 'changed'];
+    foreach ($tables as $table => $column) {
+      \Drupal::database()->update($table)
+        ->fields([$column => $timestamp])
+        ->condition('nid', $service->id())
+        ->execute();
+    }
+  }
+
+  /**
+   * Gets an array containing all update remainder mails.
+   *
+   * @return array
+   *   An array containing captured email messages.
+   */
+  protected function getReminderMails(): array {
+    return array_merge(
+      $this->getMails(['id' => 'message_notify_hel_tpm_update_reminder_service']),
+      $this->getMails(['id' => 'message_notify_hel_tpm_update_reminder_service2'])
+    );
+  }
+
+  /**
+   * Gets an array containing all service outdated mails.
+   *
+   * @return array
+   *   An array containing captured email messages.
+   */
+  protected function getOutdatedMails(): array {
+    return $this->getMails([
+      'id' => 'message_notify_hel_tpm_update_reminder_outdated',
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] lando test public/modules/custom/hel_tpm_update_reminder/tests
- [x] Tests pass
- [x] Login as admin user
- [x] Go to /admin/content
- [x] Find a service which has been sent notification messages
- [x] Select the service from a list and select "Reset update reminder" and execute the action
- [x] Confirm from key_value that hel_tpm_update_reminder.messages_sent.node.{nid} has been cleared
- [x] Login as specialist editor
- [x] Confirm you can't access "Reset update reminder" action from any of the service lists.

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
