### PR TITLE
TP-2160 Added swedish translation for group_ready_to_publish_notificat template

### DIFF
--- a/config/sync/language/sv/message.template.group_ready_to_publish_notificat.yml
+++ b/config/sync/language/sv/message.template.group_ready_to_publish_notificat.yml
@@ -1,0 +1,8 @@
+description: 'Service is ready to publish and needs audit.'
+text:
+  -
+    value: "Palvelun [message:field_node:entity:title] julkaisu odottaa hyväksyntää sivustolla [site:name] \r\n"
+    format: plain_text_format
+  -
+    value: '<p>Hei [message:field_user:entity:mail],</p><p>Sinulle on saapunut palvelun [message:field_node:entity:title] tiedot tarkistettaviksi ennen julkaisun vahvistamista.</p><p>Käythän tarkistamassa palvelun tiedot ja hyväksy palvelu julkaistavaksi, mikäli tiedot ovat oikein. Seuraa linkkiä klikkaamalla tai kopioi se selaimesi osoiteriville: <a href="[message:field_node:entity:url]">[message:field_node:entity:url]</a></p><p>Tilamuutoksen teet vaihtamalla palvelun tilan ”odottaa julkaisua”-tilasta ”julkaistu”-tilaan. Jos palvelun julkisissa tiedoissa on epäselvyyttä, ole yhteydessä muutoksen tehneeseen käyttäjään [message:field_message_author:entity:mail].</p><p>Huomioithan, että kunnan vastuukäyttäjänä sinun tulee varmistaa sisäisten työohjeiden oikeellisuus suhteessa tehtyihin muutoksiin sekä työohjeiden ajantasaisuus.</p><p>&nbsp;</p><p>Ystävällisin terveisin<br>[site:name] tiimi</p> '
+    format: full_html


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] Login as service provider
- [x] Create or edit content in **swedish** and save as draft
- [x] Change swedish translation to ready to publish
- [x] Confirm mail has been sent
- [x] Confirm mail has proper content

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
