### PR TITLE
TP-1760 Added sorting of language filter options by site language weights

### DIFF
--- a/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/SearchLanguageSelect.php
+++ b/public/modules/custom/hel_tpm_search/src/Plugin/better_exposed_filters/filter/SearchLanguageSelect.php
@@ -120,6 +120,29 @@ class SearchLanguageSelect extends RadioButtons implements ContainerFactoryPlugi
       $field['#options'][$result->getRawValue()] = $label;
     }
 
+    $this->sortOptions($field['#options']);
+
+  }
+
+  /**
+   * Sorts the given options array based on available languages.
+   *
+   * This method reorders the options array to match the language codes
+   * retrieved from the language manager.
+   *
+   * @param array &$options
+   *   The array of options to be sorted, passed by reference.
+   *
+   * @return void
+   *   This method does not return a value, as the options array is modified
+   *   directly.
+   */
+  protected function sortOptions(&$options) {
+    $languages = $this->languageManager->getLanguages();
+    foreach ($languages as $langcode => $language) {
+      $languages[$langcode] = $options[$langcode];
+    }
+    $options = $languages;
   }
 
   /**


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] Go to search
- [x] Confirm language filters are in following order: finnish, swedish, english
- [x] Login and go to /admin/config/regional/language
- [x] Change the order of languages and save
- [x] Go to search page and confirm language filter order changes 

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
