### PR TITLE
TP-2180 Added patch to remove untranslatable fields from translation export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -381,6 +381,9 @@
             },
             "drupal/views_bulk_operations": {
                 "Undefined array key exclude_mode (https://www.drupal.org/project/views_bulk_operations/issues/3566601)": "https://git.drupalcode.org/project/views_bulk_operations/-/commit/def92d84eca71b599e0776b8d1a583aef364732f.patch"
+            },
+            "drupal/tmgmt": {
+                "Computed fields and not translatable fields from paragraphs are being translated (https://www.drupal.org/project/tmgmt/issues/3382356#comment-16104653)": "https://www.drupal.org/files/issues/2025-05-12/3382356_field_translation_checks_ordered_by_granularity.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66820032cd5bb822aa841caf7c800eb6",
+    "content-hash": "2be32a74853049652615a06dec2f2e5f",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] Login and find service which has municipality specific values in internal guidance tab
- [x] Add service to translation jobs
- [x] Confirm there is no municipality specific fields in translation job
- [x] Confirm there is no other untranslatable fields in translation job

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
