### PR TITLE
TP-2201 Added patch to delete values from previously translated empty fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -384,7 +384,8 @@
             },
             "drupal/tmgmt": {
                 "Computed fields and not translatable fields from paragraphs are being translated (https://www.drupal.org/project/tmgmt/issues/3382356#comment-16104653)": "https://www.drupal.org/files/issues/2025-05-12/3382356_field_translation_checks_ordered_by_granularity.patch",
-                "Wrong field order when fields are in field groups (https://www.drupal.org/project/tmgmt/issues/3586466)": "https://www.drupal.org/files/issues/2026-05-18/reweight-grouped-fields-3586466-4.patch"
+                "Wrong field order when fields are in field groups (https://www.drupal.org/project/tmgmt/issues/3586466)": "https://www.drupal.org/files/issues/2026-05-18/reweight-grouped-fields-3586466-4.patch",
+                "Fields Content Deletions of (already Translated) Entity Content are not reflected in new Translations updates (https://www.drupal.org/project/tmgmt/issues/3278370#comment-16475359)": "https://www.drupal.org/files/issues/2026-02-18/tmgmt-content-fields-deletions-3278370-19.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10d92961660f44502297752c7487785f",
+    "content-hash": "31861e84ee3111ef0bb50c58cd618d19",
     "packages": [
         {
             "name": "ajgl/breakpoint-twig-extension",


### PR DESCRIPTION

## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] Login go to service with previous translation
- [x] Edit original language version
- [x] Remove value from one or more translatable fields
- [x] Confirm translated content still has some values from said fields
- [x] Create a new translation job
- [x] Add placeholder values to all available translation job item fields
- [x] Complete translation
- [x] Go to newly translated content
- [x] Confirm fields emptied from original language version are empty

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
