### PR TITLE
TP-1343 adjust close button for language level

### DIFF
--- a/public/themes/custom/palvelumanuaali/templates/content/taxonomy-term--language-level.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/content/taxonomy-term--language-level.html.twig
@@ -32,7 +32,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="ModalLabel">{{content.field_vernacular_title}}</h5>
-          <button type="button" class="close close-icon-button" data-bs-dismiss="modal" aria-label="Close">
+          <button type="button" class="close close-icon-button" data-bs-dismiss="modal" aria-label="{{ 'Close'|t }}">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>

--- a/public/themes/custom/palvelumanuaali/templates/content/taxonomy-term--language-level.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/content/taxonomy-term--language-level.html.twig
@@ -32,7 +32,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="ModalLabel">{{content.field_vernacular_title}}</h5>
-          <button type="button" class="close visually-hidden" data-bs-dismiss="modal" aria-label="Close">
+          <button type="button" class="close close-icon-button" data-bs-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>

--- a/translations/fi-interface-translations.po
+++ b/translations/fi-interface-translations.po
@@ -1861,3 +1861,6 @@ msgstr "Tyhjennä valinnat"
 
 msgid "Reset text search"
 msgstr "Tyhjennä tekstihaku"
+
+msgid "Close"
+msgstr "Sulje"

--- a/translations/sv-interface-translations.po
+++ b/translations/sv-interface-translations.po
@@ -1086,3 +1086,5 @@ msgstr "Töm filtren"
 msgid "Reset text search"
 msgstr "Återställ textsökning"
 
+msgid "Close"
+msgstr "Stäng"


### PR DESCRIPTION
## Actions for applying the changes locally
`lando drush cr`
` lando drush locale:import fi ../translations/fi-interface-translations.po`
` lando drush locale:import sv ../translations/sv-interface-translations.po`

## Testing instructions
- [x] Go to a service page with set language (and level)
- [x] Open language level explanation popup
- [x] Ensure modal has close button...
- [x] ... and it works
- [x] Ensure modal button has set traslated aria-label


## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
