### PR TITLE
TP-2223 Created custom link to latest translation revision views field to fix issue of missing titles in translations

### DIFF
--- a/config/sync/language/en/views.view.service_rtb_publish_stats.yml
+++ b/config/sync/language/en/views.view.service_rtb_publish_stats.yml
@@ -7,8 +7,6 @@ display:
       fields:
         title:
           label: Service
-        link_to_latest_revision:
-          label: Service
         changed:
           label: Changed
         moderation_state:
@@ -20,3 +18,5 @@ display:
         edit_node:
           label: Operations
           text: Edit
+        link_to_latest_translation_revision:
+          label: Service

--- a/config/sync/views.view.service_rtb_publish_stats.yml
+++ b/config/sync/views.view.service_rtb_publish_stats.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - content_moderation
     - group
+    - hel_tpm_general
     - hel_tpm_service_stats
     - node
     - user
@@ -753,15 +754,15 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        link_to_latest_revision:
-          id: link_to_latest_revision
+        link_to_latest_translation_revision:
+          id: link_to_latest_translation_revision
           table: node_revision
-          field: link_to_latest_revision
+          field: link_to_latest_translation_revision
           relationship: nid
           group_type: group
           admin_label: ''
           entity_type: node
-          plugin_id: link_to_latest_revision
+          plugin_id: link_to_latest_translation_revision
           label: Palvelu
           exclude: false
           alter:
@@ -795,7 +796,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -804,8 +805,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: ''
-          output_url_as_text: false
-          absolute: false
+          output_url_as_text: 0
+          absolute: 0
         changed:
           id: changed
           table: node_field_revision

--- a/public/modules/custom/hel_tpm_general/hel_tpm_general.views.inc
+++ b/public/modules/custom/hel_tpm_general/hel_tpm_general.views.inc
@@ -24,4 +24,11 @@ function hel_tpm_general_views_data_alter(array &$data) {
       'id' => 'hel_tpm_general_add_service_button',
     ],
   ];
+  $data['node_revision']['link_to_latest_translation_revision'] = [
+    'title' => t('Link to latest translation revision'),
+    'field' => [
+      'id' => 'link_to_latest_translation_revision',
+      'help' => t('Link to latest translation revision'),
+    ],
+  ];
 }

--- a/public/modules/custom/hel_tpm_general/src/Plugin/views/field/LinkToLatestTranslationRevision.php
+++ b/public/modules/custom/hel_tpm_general/src/Plugin/views/field/LinkToLatestTranslationRevision.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hel_tpm_general\Plugin\views\field;
+
+use Drupal\views\Plugin\views\field\LinkToLatestRevision;
+use Drupal\views\ResultRow;
+
+/**
+ * Provides Link to latest translation revision field handler.
+ *
+ * @ViewsField("link_to_latest_translation_revision")
+ *
+ * @DCG
+ * The plugin needs to be assigned to a specific table column through
+ * hook_views_data() or hook_views_data_alter().
+ * Put the following code to hel_tpm_general.views.inc file.
+ * @code
+ * function foo_views_data_alter(array &$data): void {
+ *   $data['node']['foo_example']['field'] = [
+ *     'title' => t('Example'),
+ *     'help' => t('Custom example field.'),
+ *     'id' => 'foo_example',
+ *   ];
+ * }
+ * @endcode
+ */
+final class LinkToLatestTranslationRevision extends LinkToLatestRevision {
+
+  /**
+   * Retrieves the URL information for a given result row.
+   *
+   * This method constructs a URL for the entity associated with the given
+   * result row. If the language manager is multilingual, it retrieves the
+   * entity translation and appends language-specific information.
+   *
+   * @param \Drupal\views\ResultRow $row
+   *   The result row containing the data used to retrieve the entity.
+   *
+   * @return \Drupal\Core\Url
+   *   The generated URL for the entity, with set template and absolute URL
+   *   flag based on the provided options.
+   */
+  protected function getUrlInfo(ResultRow $row) {
+    $entity = $this->getEntity($row);
+    $template = 'latest-version';
+    if ($this->languageManager->isMultilingual()) {
+      $entity = $this->getEntityTranslationByRelationship($entity, $row);
+      $this->addLangcode($row);
+    }
+    return $entity->toUrl($template)->setAbsolute($this->options['absolute']);
+  }
+
+  /**
+   * Checks if the URL access is allowed for the specified entity.
+   *
+   * This method determines if the current user has access to edit the given
+   * entity, taking into account possible translations in a multilingual setup.
+   *
+   * @param \ResultRow $row
+   *   The result row that contains the entity to check access for.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result indicating whether the operation is permitted.
+   */
+  protected function checkUrlAccess(ResultRow $row) {
+    $entity = $this->getEntity($row);
+    if ($this->languageManager->isMultilingual()) {
+      $entity = $this->getEntityTranslationByRelationship($entity, $row);
+    }
+    // Check access on the translated entity directly instead of using the
+    // named route check, which loads the default-language entity from route
+    // parameters and may incorrectly return forbidden for translations that
+    // have a pending revision only in their language.
+    return $entity->access('edit', $this->currentUser(), TRUE);
+  }
+
+}

--- a/public/modules/custom/hel_tpm_general/tests/src/Kernel/LinkToLatestTranslationRevisionTest.php
+++ b/public/modules/custom/hel_tpm_general/tests/src/Kernel/LinkToLatestTranslationRevisionTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\hel_tpm_general\Kernel;
+
+use Drupal\Core\Access\AccessManagerInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\hel_tpm_general\Plugin\views\field\LinkToLatestTranslationRevision;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\views\ResultRow;
+
+/**
+ * Tests the link_to_latest_translation_revision Views field plugin.
+ *
+ * @group hel_tpm_general
+ */
+final class LinkToLatestTranslationRevisionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'language',
+    'content_translation',
+    'node',
+    'views',
+  ];
+
+  /**
+   * Tests that URL generation always uses the latest-version link template.
+   */
+  public function testGetUrlInfoUsesLatestVersionTemplate(): void {
+    $url = Url::fromRoute('entity.node.latest_version', ['node' => 1]);
+    $entity = $this->createEntityExpectingUrl('latest-version', $url);
+
+    $plugin = $this->createPlugin();
+    $this->setOptions($plugin, absolute: TRUE);
+
+    $result = $this->invokeProtectedMethod($plugin, 'getUrlInfo', [
+      $this->createRow($entity),
+    ]);
+
+    $this->assertSame($url, $result);
+    $this->assertTrue($result->getOption('absolute'));
+  }
+
+  /**
+   * Tests that multilingual URL generation adds language information.
+   */
+  public function testGetUrlInfoAddsLanguageWhenMultilingual(): void {
+    $language = $this->createLanguage('fi');
+    $url = Url::fromRoute('entity.node.latest_version', ['node' => 1]);
+
+    $entity = $this->createEntityExpectingUrl('latest-version', $url);
+    $entity
+      ->method('language')
+      ->willReturn($language);
+
+    $plugin = $this->createPlugin(multilingual: TRUE);
+    $this->setOptions($plugin);
+
+    $result = $this->invokeProtectedMethod($plugin, 'getUrlInfo', [
+      $this->createRow($entity),
+    ]);
+    $options = $this->getProtectedProperty($plugin, 'options');
+
+    $this->assertSame($url, $result);
+    $this->assertFalse($result->getOption('absolute'));
+    $this->assertSame($language, $options['alter']['language']);
+  }
+
+  /**
+   * Tests that access is checked directly on the entity.
+   */
+  public function testCheckUrlAccessChecksEditAccessOnEntity(): void {
+    $account = $this->createMock(AccountInterface::class);
+    $entity = $this->createEntityExpectingAccess($account, AccessResult::allowed());
+
+    $plugin = $this->createPlugin();
+    $this->setCurrentUser($plugin, $account);
+    $this->setOptions($plugin);
+
+    $result = $this->invokeProtectedMethod($plugin, 'checkUrlAccess', [
+      $this->createRow($entity),
+    ]);
+
+    $this->assertInstanceOf(AccessResultInterface::class, $result);
+    $this->assertTrue($result->isAllowed());
+  }
+
+  /**
+   * Tests that multilingual access still checks edit access on the entity.
+   */
+  public function testCheckUrlAccessChecksEditAccessWhenMultilingual(): void {
+    $account = $this->createMock(AccountInterface::class);
+    $language = $this->createLanguage('fi');
+
+    $entity = $this->createEntityExpectingAccess($account, AccessResult::allowed());
+    $entity
+      ->method('language')
+      ->willReturn($language);
+
+    $plugin = $this->createPlugin(multilingual: TRUE);
+    $this->setCurrentUser($plugin, $account);
+    $this->setOptions($plugin);
+
+    $result = $this->invokeProtectedMethod($plugin, 'checkUrlAccess', [
+      $this->createRow($entity),
+    ]);
+
+    $this->assertInstanceOf(AccessResultInterface::class, $result);
+    $this->assertTrue($result->isAllowed());
+  }
+
+  /**
+   * Tests that route access is not used for the latest revision link.
+   */
+  public function testCheckUrlAccessDoesNotUseNamedRouteAccess(): void {
+    $account = $this->createMock(AccountInterface::class);
+    $entity = $this->createEntityExpectingAccess($account, AccessResult::allowed());
+
+    $access_manager = $this->createMock(AccessManagerInterface::class);
+    $access_manager
+      ->expects($this->never())
+      ->method('checkNamedRoute');
+
+    $plugin = $this->createPlugin(access_manager: $access_manager);
+    $this->setCurrentUser($plugin, $account);
+    $this->setOptions($plugin);
+
+    $result = $this->invokeProtectedMethod($plugin, 'checkUrlAccess', [
+      $this->createRow($entity),
+    ]);
+
+    $this->assertInstanceOf(AccessResultInterface::class, $result);
+    $this->assertTrue($result->isAllowed());
+  }
+
+  /**
+   * Tests render output for denied edit access results.
+   *
+   * @dataProvider deniedAccessResultsProvider
+   */
+  public function testRenderDoesNotOutputLinkWhenEditAccessIsDenied(AccessResultInterface $access_result): void {
+    $account = $this->createMock(AccountInterface::class);
+    $entity = $this->createEntityExpectingAccess($account, $access_result);
+    $entity
+      ->expects($this->never())
+      ->method('toUrl');
+
+    $plugin = $this->createPlugin();
+    $this->setCurrentUser($plugin, $account);
+    $this->setOptions($plugin, [
+      'text' => 'View latest revision',
+      'output_url_as_text' => FALSE,
+    ]);
+
+    $build = $plugin->render($this->createRow($entity));
+
+    $this->assertIsArray($build);
+    $this->assertSame('', $build['#markup']);
+  }
+
+  /**
+   * Provides denied access results.
+   *
+   * @return array<string, array{\Drupal\Core\Access\AccessResultInterface}>
+   *   Access result test cases.
+   */
+  public function deniedAccessResultsProvider(): array {
+    return [
+      'forbidden access' => [AccessResult::forbidden()],
+      'neutral access' => [AccessResult::neutral()],
+    ];
+  }
+
+  /**
+   * Creates the plugin under test.
+   *
+   * @param bool $multilingual
+   *   Whether the language manager should report multilingual support.
+   * @param \Drupal\Core\Access\AccessManagerInterface|null $access_manager
+   *   The access manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface|null $entity_repository
+   *   The entity repository.
+   *
+   * @return \Drupal\hel_tpm_general\Plugin\views\field\LinkToLatestTranslationRevision
+   *   The plugin instance.
+   */
+  private function createPlugin(
+    bool $multilingual = FALSE,
+    ?AccessManagerInterface $access_manager = NULL,
+    ?EntityRepositoryInterface $entity_repository = NULL,
+  ): LinkToLatestTranslationRevision {
+    $access_manager ??= $this->createMock(AccessManagerInterface::class);
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_repository ??= $this->createMock(EntityRepositoryInterface::class);
+
+    $language_manager = $this->createMock(LanguageManagerInterface::class);
+    $language_manager
+      ->method('isMultilingual')
+      ->willReturn($multilingual);
+
+    return new LinkToLatestTranslationRevision(
+      [],
+      'link_to_latest_translation_revision',
+      [],
+      $access_manager,
+      $entity_type_manager,
+      $entity_repository,
+      $language_manager,
+    );
+  }
+
+  /**
+   * Creates a Views result row for the given entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The row entity.
+   *
+   * @return \Drupal\views\ResultRow
+   *   The result row.
+   */
+  private function createRow(EntityInterface $entity): ResultRow {
+    $row = new ResultRow();
+    $row->_entity = $entity;
+
+    return $row;
+  }
+
+  /**
+   * Creates a language mock.
+   *
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return \Drupal\Core\Language\LanguageInterface
+   *   The language mock.
+   */
+  private function createLanguage(string $langcode): LanguageInterface {
+    $language = $this->createMock(LanguageInterface::class);
+    $language
+      ->method('getId')
+      ->willReturn($langcode);
+
+    return $language;
+  }
+
+  /**
+   * Creates an entity mock expecting URL generation.
+   *
+   * @param string $template
+   *   The expected link template.
+   * @param \Drupal\Core\Url $url
+   *   The URL to return.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity mock.
+   */
+  private function createEntityExpectingUrl(string $template, Url $url): EntityInterface {
+    $entity = $this->createMock(EntityInterface::class);
+    $entity
+      ->expects($this->once())
+      ->method('toUrl')
+      ->with($template)
+      ->willReturn($url);
+
+    return $entity;
+  }
+
+  /**
+   * Creates an entity mock expecting an edit access check.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account expected in the access check.
+   * @param \Drupal\Core\Access\AccessResultInterface $access_result
+   *   The access result to return.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The entity mock.
+   */
+  private function createEntityExpectingAccess(AccountInterface $account, AccessResultInterface $access_result): EntityInterface {
+    $entity = $this->createMock(EntityInterface::class);
+    $entity
+      ->expects($this->once())
+      ->method('access')
+      ->with('edit', $account, TRUE)
+      ->willReturn($access_result);
+
+    return $entity;
+  }
+
+  /**
+   * Sets plugin options.
+   *
+   * @param \Drupal\hel_tpm_general\Plugin\views\field\LinkToLatestTranslationRevision $plugin
+   *   The plugin.
+   * @param array $extra_options
+   *   Additional options.
+   * @param bool $absolute
+   *   Whether generated URLs should be absolute.
+   */
+  private function setOptions(LinkToLatestTranslationRevision $plugin, array $extra_options = [], bool $absolute = FALSE): void {
+    $this->setProtectedProperty($plugin, 'options', $extra_options + [
+      'relationship' => 'none',
+      'absolute' => $absolute,
+      'alter' => [],
+    ]);
+  }
+
+  /**
+   * Sets the current user on the plugin.
+   *
+   * @param \Drupal\hel_tpm_general\Plugin\views\field\LinkToLatestTranslationRevision $plugin
+   *   The plugin.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user.
+   */
+  private function setCurrentUser(LinkToLatestTranslationRevision $plugin, AccountInterface $account): void {
+    $this->setProtectedProperty($plugin, 'currentUser', $account);
+  }
+
+  /**
+   * Invokes a protected method.
+   *
+   * @param object $object
+   *   The object.
+   * @param string $method
+   *   The method name.
+   * @param array $arguments
+   *   The method arguments.
+   *
+   * @return mixed
+   *   The method return value.
+   */
+  private function invokeProtectedMethod(object $object, string $method, array $arguments = []): mixed {
+    $reflection = new \ReflectionClass($object);
+    $reflection_method = $reflection->getMethod($method);
+    $reflection_method->setAccessible(TRUE);
+
+    return $reflection_method->invokeArgs($object, $arguments);
+  }
+
+  /**
+   * Sets a protected property value.
+   *
+   * @param object $object
+   *   The object.
+   * @param string $property
+   *   The property name.
+   * @param mixed $value
+   *   The property value.
+   */
+  private function setProtectedProperty(object $object, string $property, mixed $value): void {
+    $reflection = new \ReflectionClass($object);
+
+    while (!$reflection->hasProperty($property)) {
+      $reflection = $reflection->getParentClass();
+    }
+
+    $reflection_property = $reflection->getProperty($property);
+    $reflection_property->setAccessible(TRUE);
+    $reflection_property->setValue($object, $value);
+  }
+
+  /**
+   * Gets a protected property value.
+   *
+   * @param object $object
+   *   The object.
+   * @param string $property
+   *   The property name.
+   *
+   * @return mixed
+   *   The property value.
+   */
+  private function getProtectedProperty(object $object, string $property): mixed {
+    $reflection = new \ReflectionClass($object);
+
+    while (!$reflection->hasProperty($property)) {
+      $reflection = $reflection->getParentClass();
+    }
+
+    $reflection_property = $reflection->getProperty($property);
+    $reflection_property->setAccessible(TRUE);
+
+    return $reflection_property->getValue($object);
+  }
+
+}


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] lando test public/modules/custom/hel_tpm_general/tests/src/Kernel/LinkToLatestTranslationRevisionTest.php 
- [x] Tests pass
- [x] Login as admin
- [x] Go to a sub group
- [x] Create or find a service which default translation is published
- [x] Add or edit translation for selected service
- [x] Save as ready to publish
- [x] Change ui language back to default language
- [x] Go to parent groups "Vastuupalvelut" tab
- [x] Confirm service is listed in RTB services view
- [x] Confirm title is shown and link links to latest revision


## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
