### PR TITLE
TP-1465 Adjust element dom order and link role for taxonomy cards

### DIFF
--- a/public/themes/custom/palvelumanuaali/components/02-molecules/card/card.twig
+++ b/public/themes/custom/palvelumanuaali/components/02-molecules/card/card.twig
@@ -295,4 +295,7 @@
             {% endblock %}
             </div>
       {% endif %}
+  {% block card__flag %}
+
+  {% endblock %}
 </div>

--- a/public/themes/custom/palvelumanuaali/templates/content/node--taxonomy-card.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/content/node--taxonomy-card.html.twig
@@ -85,7 +85,7 @@
   card__language: content.field_service_languages,
   card__price: content.field_free_service,
 } %}
-  {% block card__img %}
+  {% block card__flag %}
     {% if content.flag_cart  %}
       <div class='small-message-wrapper small-message-wrapper--taxonomy-card'>
         {{ content.flag_cart }}

--- a/public/themes/custom/palvelumanuaali/templates/flag_list_flag.html.twig
+++ b/public/themes/custom/palvelumanuaali/templates/flag_list_flag.html.twig
@@ -47,7 +47,7 @@
 {% endif %}
 
 {# Set nofollow to prevent search bots from crawling anonymous flag links #}
-{% set attributes = attributes.setAttribute('rel', 'nofollow').setAttribute('title', title) %}
+{% set attributes = attributes.setAttribute('rel', 'nofollow').setAttribute('title', title).setAttribute('role','button') %}
 
 <div class="{{classes|join(' ')}}"><a{{ attributes }}>{{ title }}</a></div>
 {% endapply %}


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [ ] Navigate to search page 
- [ ] Use keyboard to tab through the taxonomy cards and ensure content is navigated first and favorite button last.
- [ ] Ensure favorite link has "role=button" 

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
