### PR TITLE
TP-1986 Hide other services block from outdate action

### DIFF
--- a/config/sync/block.block.palvelumanuaali_views_block__other_services_block_1.yml
+++ b/config/sync/block.block.palvelumanuaali_views_block__other_services_block_1.yml
@@ -36,4 +36,4 @@ visibility:
   request_path_exclusion:
     id: request_path_exclusion
     negate: true
-    pages: "/*/edit\r\n/*/edit/*\r\n/*/delete\r\n/*/delete/*\r\n/*/revisions\r\n/*/revisions/*\r\n/*/translations\r\n/*/translations/*"
+    pages: "/*/edit\r\n/*/edit/*\r\n/*/delete\r\n/*/delete/*\r\n/*/revisions\r\n/*/revisions/*\r\n/*/translations\r\n/*/translations/*\r\n/node/*/outdated"


### PR DESCRIPTION
## Actions for applying the changes locally
`lando composer install && lando drush deploy`

## Testing instructions
- [x] Login and got to group page: `/group/<ID>/services`
- [x] "Set oudated" for some published service.
- [x] At the confirmation page, there is no "Take a look at these services" section.
- [x] When viewing the node, the section is still visible.

## Review checklist
- [ ] The code conforms to Drupal coding standards.
- [ ] I have reviewed the code for security and quality issues.
- [ ] I have tested the code with the proper **user** roles.
